### PR TITLE
feat: add skill growth endpoints to registry broker client

### DIFF
--- a/__tests__/services/registry-broker-skills-client.test.ts
+++ b/__tests__/services/registry-broker-skills-client.test.ts
@@ -15,117 +15,6 @@ function createResponse(payload: {
   } as unknown as Response;
 }
 
-function createMockPreviewReport(overrides: Record<string, unknown> = {}) {
-  return {
-    schema_version: 'skill-preview.v1',
-    tool_version: '1.0.0',
-    preview_id: 'preview_demo',
-    repo_url: 'https://github.com/hashgraph-online/registry-broker-skill',
-    repo_owner: 'hashgraph-online',
-    repo_name: 'registry-broker-skill',
-    default_branch: 'main',
-    commit_sha: 'abc123',
-    ref: 'refs/pull/5/merge',
-    event_name: 'pull_request',
-    workflow_run_url:
-      'https://github.com/hashgraph-online/registry-broker-skill/actions/runs/123456789',
-    skill_dir: '.',
-    name: 'preview-skill',
-    version: '0.1.0',
-    validation_status: 'passed',
-    findings: [],
-    package_summary: {
-      fileCount: 2,
-    },
-    suggested_next_steps: [],
-    generated_at: '2026-04-04T10:00:00.000Z',
-    ...overrides,
-  };
-}
-
-function createMockPreviewRecord(overrides: Record<string, unknown> = {}) {
-  return {
-    id: 'preview-1',
-    previewId: 'preview_demo',
-    source: 'github-oidc',
-    generatedAt: '2026-04-04T10:00:00.000Z',
-    expiresAt: '2026-04-11T10:00:00.000Z',
-    statusUrl: 'https://hol.org/registry/skills/preview/preview_demo',
-    authoritative: false,
-    report: createMockPreviewReport(),
-    ...overrides,
-  };
-}
-
-function createMockPreviewLookupResponse(
-  overrides: Record<string, unknown> = {},
-) {
-  return {
-    found: true,
-    authoritative: false,
-    statusUrl: 'https://hol.org/registry/skills/preview/preview_demo',
-    expiresAt: '2026-04-11T10:00:00.000Z',
-    preview: createMockPreviewRecord(),
-    ...overrides,
-  };
-}
-
-function createMockSkillStatus(overrides: Record<string, unknown> = {}) {
-  return {
-    name: 'registry-broker',
-    version: '1.2.3',
-    published: true,
-    verifiedDomain: true,
-    trustTier: 'hardened',
-    badgeMetric: 'tier',
-    checks: {
-      repoCommitIntegrity: true,
-      manifestIntegrity: true,
-      domainProof: true,
-    },
-    verificationSignals: {
-      publisherBound: true,
-      domainProof: true,
-      verifiedDomain: true,
-      previewValidated: false,
-    },
-    provenanceSignals: {
-      repoCommitIntegrity: true,
-      manifestIntegrity: true,
-      canonicalRelease: true,
-      previewAvailable: false,
-      previewAuthoritative: false,
-    },
-    nextSteps: [
-      {
-        kind: 'share_status',
-        priority: 10,
-        id: 'share',
-        label: 'Share the canonical install links',
-        description:
-          'Copy pinned SKILL.md, manifest, and badge URLs from the registry detail page after each release.',
-        url: 'https://hol.org/registry/skills',
-        href: 'https://hol.org/registry/skills',
-        command: null,
-      },
-    ],
-    publisher: {
-      cliPackageUrl: 'https://www.npmjs.com/package/skill-publish',
-      cliCommand: 'npx skill-publish',
-      actionMarketplaceUrl:
-        'https://github.com/marketplace/actions/skill-publish',
-      repositoryUrl: 'https://github.com/hashgraph-online/skill-publish',
-      guideUrl: 'https://hol.org/registry/skills/about',
-      docsUrl: 'https://hol.org/registry/docs',
-      submitUrl: 'https://hol.org/registry/skills/submit',
-      skillsIndexUrl: 'https://hol.org/registry/skills',
-      quickstartCommands: [],
-      templatePresets: [],
-    },
-    ...overrides,
-  };
-}
-
 describe('RegistryBrokerClient skill contract methods', () => {
   const fetchImplementation = jest.fn<typeof fetch>();
 
@@ -201,7 +90,72 @@ describe('RegistryBrokerClient skill contract methods', () => {
   it('retrieves skill trust-tier status', async () => {
     fetchImplementation.mockResolvedValueOnce(
       createResponse({
-        json: async () => createMockSkillStatus(),
+        json: async () => ({
+          name: 'preview-skill',
+          version: '0.1.0',
+          published: false,
+          verifiedDomain: false,
+          trustTier: 'validated',
+          badgeMetric: 'tier',
+          checks: {
+            repoCommitIntegrity: false,
+            manifestIntegrity: false,
+            domainProof: false,
+          },
+          verificationSignals: {
+            publisherBound: false,
+            domainProof: false,
+            verifiedDomain: false,
+            previewValidated: true,
+          },
+          provenanceSignals: {
+            repoCommitIntegrity: false,
+            manifestIntegrity: false,
+            canonicalRelease: false,
+            previewAvailable: true,
+            previewAuthoritative: false,
+          },
+          nextSteps: [
+            {
+              kind: 'publish_first_release',
+              priority: 100,
+              id: 'publish',
+              label: 'Publish the first immutable release',
+              description:
+                'This repo already passes validate-first checks. Publish an immutable release to mint canonical install URLs and a durable registry page.',
+              url: 'https://hol.org/registry/skills/submit',
+              href: 'https://hol.org/registry/skills/submit',
+              command: 'npx skill-publish publish',
+            },
+          ],
+          publisher: {
+            cliPackageUrl: 'https://www.npmjs.com/package/skill-publish',
+            cliCommand: 'npx skill-publish',
+            actionMarketplaceUrl:
+              'https://github.com/marketplace/actions/skill-publish',
+            repositoryUrl: 'https://github.com/hashgraph-online/skill-publish',
+            guideUrl: 'https://hol.org/registry/skills/about',
+            docsUrl: 'https://hol.org/registry/docs',
+            submitUrl: 'https://hol.org/registry/skills/submit',
+            skillsIndexUrl: 'https://hol.org/registry/skills',
+            quickstartCommands: [],
+            templatePresets: [],
+          },
+          preview: {
+            previewId: 'preview_demo',
+            repoUrl:
+              'https://github.com/hashgraph-online/registry-broker-skill',
+            repoOwner: 'hashgraph-online',
+            repoName: 'registry-broker-skill',
+            commitSha: 'abc123',
+            ref: 'refs/pull/5/merge',
+            eventName: 'pull_request',
+            skillDir: '.',
+            generatedAt: '2026-04-04T10:00:00.000Z',
+            expiresAt: '2026-04-11T10:00:00.000Z',
+            statusUrl: 'https://hol.org/registry/skills/preview-skill',
+          },
+        }),
       }),
     );
 
@@ -211,72 +165,66 @@ describe('RegistryBrokerClient skill contract methods', () => {
     });
 
     const status = await client.getSkillStatus({
-      name: 'registry-broker',
-      version: '1.2.3',
+      name: 'preview-skill',
+      version: '0.1.0',
     });
 
-    expect(status.trustTier).toBe('hardened');
-    expect(status.checks.domainProof).toBe(true);
+    expect(status.trustTier).toBe('validated');
+    expect(status.preview?.repoName).toBe('registry-broker-skill');
+    expect(status.preview?.previewId).toBe('preview_demo');
+    expect(status.checks.domainProof).toBe(false);
     expect(status.badgeMetric).toBe('tier');
     expect(fetchImplementation).toHaveBeenCalledWith(
-      'https://api.example.com/api/v1/skills/status?name=registry-broker&version=1.2.3',
+      'https://api.example.com/api/v1/skills/status?name=preview-skill&version=0.1.0',
       expect.objectContaining({ method: 'GET' }),
     );
-  });
-
-  it('keeps legacy skill status payloads parseable during rollout', async () => {
-    fetchImplementation.mockResolvedValueOnce(
-      createResponse({
-        json: async () =>
-          createMockSkillStatus({
-            trustTier: 'unpublished',
-            nextSteps: [
-              {
-                id: 'share',
-                label: 'Share later',
-                description: 'Legacy brokers omit lifecycle metadata here.',
-                href: 'https://hol.org/registry/skills',
-                command: null,
-              },
-            ],
-            verificationSignals: undefined,
-            provenanceSignals: undefined,
-          }),
-      }),
-    );
-
-    const client = new RegistryBrokerClient({
-      baseUrl: 'https://api.example.com',
-      fetchImplementation,
-    });
-
-    const status = await client.getSkillStatus({
-      name: 'registry-broker',
-    });
-
-    expect(status.trustTier).toBe('unpublished');
-    expect(status.nextSteps[0]?.kind).toBeUndefined();
-    expect(status.verificationSignals.previewValidated).toBe(false);
-    expect(status.provenanceSignals.canonicalRelease).toBe(false);
   });
 
   it('uploads a GitHub OIDC skill preview report', async () => {
     fetchImplementation.mockResolvedValueOnce(
       createResponse({
-        json: async () =>
-          createMockPreviewRecord({
-            report: createMockPreviewReport({
-              suggested_next_steps: [
-                {
-                  id: 'publish',
-                  label: 'Publish',
-                  description: 'Publish the validated skill.',
-                  href: 'https://hol.org/registry/skills/submit',
-                  command: 'npx skill-publish publish',
-                },
-              ],
-            }),
-          }),
+        json: async () => ({
+          id: 'preview-1',
+          previewId: 'preview_demo',
+          source: 'github-oidc',
+          generatedAt: '2026-04-04T10:00:00.000Z',
+          expiresAt: '2026-04-11T10:00:00.000Z',
+          statusUrl: 'https://hol.org/registry/skills/preview-skill',
+          authoritative: false,
+          report: {
+            schema_version: 'skill-preview.v1',
+            tool_version: '1.0.0',
+            preview_id: 'preview_demo',
+            repo_url:
+              'https://github.com/hashgraph-online/registry-broker-skill',
+            repo_owner: 'hashgraph-online',
+            repo_name: 'registry-broker-skill',
+            default_branch: 'main',
+            commit_sha: 'abc123',
+            ref: 'refs/pull/5/merge',
+            event_name: 'pull_request',
+            workflow_run_url:
+              'https://github.com/hashgraph-online/registry-broker-skill/actions/runs/123456789',
+            skill_dir: '.',
+            name: 'preview-skill',
+            version: '0.1.0',
+            validation_status: 'passed',
+            findings: [],
+            package_summary: {
+              fileCount: 2,
+            },
+            suggested_next_steps: [
+              {
+                id: 'publish',
+                label: 'Publish',
+                description: 'Publish the validated skill.',
+                href: 'https://hol.org/registry/skills/submit',
+                command: 'npx skill-publish publish',
+              },
+            ],
+            generated_at: '2026-04-04T10:00:00.000Z',
+          },
+        }),
       }),
     );
 
@@ -287,7 +235,30 @@ describe('RegistryBrokerClient skill contract methods', () => {
 
     const preview = await client.uploadSkillPreviewFromGithubOidc({
       token: 'preview-token',
-      report: createMockPreviewReport(),
+      report: {
+        schema_version: 'skill-preview.v1',
+        tool_version: '1.0.0',
+        preview_id: 'preview_demo',
+        repo_url: 'https://github.com/hashgraph-online/registry-broker-skill',
+        repo_owner: 'hashgraph-online',
+        repo_name: 'registry-broker-skill',
+        default_branch: 'main',
+        commit_sha: 'abc123',
+        ref: 'refs/pull/5/merge',
+        event_name: 'pull_request',
+        workflow_run_url:
+          'https://github.com/hashgraph-online/registry-broker-skill/actions/runs/123456789',
+        skill_dir: '.',
+        name: 'preview-skill',
+        version: '0.1.0',
+        validation_status: 'passed',
+        findings: [],
+        package_summary: {
+          fileCount: 2,
+        },
+        suggested_next_steps: [],
+        generated_at: '2026-04-04T10:00:00.000Z',
+      },
     });
 
     expect(preview.id).toBe('preview-1');
@@ -308,7 +279,46 @@ describe('RegistryBrokerClient skill contract methods', () => {
   it('retrieves a stored skill preview by name and version', async () => {
     fetchImplementation.mockResolvedValueOnce(
       createResponse({
-        json: async () => createMockPreviewLookupResponse(),
+        json: async () => ({
+          found: true,
+          authoritative: true,
+          statusUrl: 'https://hol.org/registry/skills/preview/preview_demo',
+          expiresAt: '2026-04-11T10:00:00.000Z',
+          preview: {
+            id: 'preview-1',
+            previewId: 'preview_demo',
+            source: 'github-oidc',
+            generatedAt: '2026-04-04T10:00:00.000Z',
+            expiresAt: '2026-04-11T10:00:00.000Z',
+            statusUrl: 'https://hol.org/registry/skills/preview/preview_demo',
+            authoritative: true,
+            report: {
+              schema_version: 'skill-preview.v1',
+              tool_version: '1.0.0',
+              preview_id: 'preview_demo',
+              repo_url:
+                'https://github.com/hashgraph-online/registry-broker-skill',
+              repo_owner: 'hashgraph-online',
+              repo_name: 'registry-broker-skill',
+              default_branch: 'main',
+              commit_sha: 'abc123',
+              ref: 'refs/pull/5/merge',
+              event_name: 'pull_request',
+              workflow_run_url:
+                'https://github.com/hashgraph-online/registry-broker-skill/actions/runs/123456789',
+              skill_dir: '.',
+              name: 'preview-skill',
+              version: '0.1.0',
+              validation_status: 'passed',
+              findings: [],
+              package_summary: {
+                fileCount: 2,
+              },
+              suggested_next_steps: [],
+              generated_at: '2026-04-04T10:00:00.000Z',
+            },
+          },
+        }),
       }),
     );
 
@@ -323,6 +333,7 @@ describe('RegistryBrokerClient skill contract methods', () => {
     });
 
     expect(preview.found).toBe(true);
+    expect(preview.authoritative).toBe(true);
     expect(preview.preview?.report.repo_owner).toBe('hashgraph-online');
     expect(fetchImplementation).toHaveBeenCalledWith(
       'https://api.example.com/api/v1/skills/preview?name=preview-skill&version=0.1.0',
@@ -330,14 +341,15 @@ describe('RegistryBrokerClient skill contract methods', () => {
     );
   });
 
-  it('accepts authoritative preview lookup responses during rollout', async () => {
+  it('supports tier badge lookups for skill lifecycle flows', async () => {
     fetchImplementation.mockResolvedValueOnce(
       createResponse({
-        json: async () =>
-          createMockPreviewLookupResponse({
-            authoritative: true,
-            preview: createMockPreviewRecord({ authoritative: true }),
-          }),
+        json: async () => ({
+          schemaVersion: 1,
+          label: 'registry-broker',
+          message: 'verified',
+          color: 'brightgreen',
+        }),
       }),
     );
 
@@ -346,13 +358,16 @@ describe('RegistryBrokerClient skill contract methods', () => {
       fetchImplementation,
     });
 
-    const preview = await client.getSkillPreview({
-      name: 'preview-skill',
-      version: '0.1.0',
+    const badge = await client.getSkillBadge({
+      name: 'registry-broker',
+      metric: 'tier',
     });
 
-    expect(preview.authoritative).toBe(true);
-    expect(preview.preview?.authoritative).toBe(true);
+    expect(badge.message).toBe('verified');
+    expect(fetchImplementation).toHaveBeenCalledWith(
+      'https://api.example.com/api/v1/skills/badge?name=registry-broker&metric=tier',
+      expect.objectContaining({ method: 'GET' }),
+    );
   });
 
   it('retrieves repo-based skill status and preview metadata', async () => {
@@ -456,6 +471,110 @@ describe('RegistryBrokerClient skill contract methods', () => {
     );
   });
 
+  it('retrieves anonymous quote preview estimates', async () => {
+    fetchImplementation.mockResolvedValueOnce(
+      createResponse({
+        json: async () => ({
+          estimatedCredits: { min: 64, max: 76 },
+          estimatedHbar: { min: 0.64, max: 0.76 },
+          pricingVersion: 'heuristic-v1',
+          assumptions: [
+            'Estimate derived from package file count and total bytes.',
+          ],
+          purchaseUrl: 'https://hol.org/registry/skills/submit',
+          publishUrl: 'https://hol.org/registry/skills/submit',
+          verificationUrl: 'https://hol.org/registry/skills/submit',
+        }),
+      }),
+    );
+
+    const client = new RegistryBrokerClient({
+      baseUrl: 'https://api.example.com',
+      fetchImplementation,
+    });
+
+    const quote = await client.quoteSkillPublishPreview({
+      fileCount: 4,
+      totalBytes: 18_500,
+      name: 'preview-skill',
+      version: '0.1.0',
+      repoUrl: 'https://github.com/hashgraph-online/registry-broker-skill',
+      skillDir: '.',
+    });
+
+    expect(quote.estimatedCredits.min).toBe(64);
+    expect(quote.pricingVersion).toBe('heuristic-v1');
+    expect(fetchImplementation).toHaveBeenCalledWith(
+      'https://api.example.com/api/v1/skills/quote-preview',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          fileCount: 4,
+          totalBytes: 18_500,
+          name: 'preview-skill',
+          version: '0.1.0',
+          repoUrl: 'https://github.com/hashgraph-online/registry-broker-skill',
+          skillDir: '.',
+        }),
+      }),
+    );
+  });
+
+  it('retrieves repo conversion signals for growth-loop routing', async () => {
+    fetchImplementation.mockResolvedValueOnce(
+      createResponse({
+        json: async () => ({
+          repoUrl: 'https://github.com/hashgraph-online/registry-broker-skill',
+          skillDir: '.',
+          trustTier: 'validated',
+          actionInstalled: true,
+          previewUploaded: true,
+          previewId: 'preview_demo',
+          lastValidateSuccessAt: '2026-04-04T10:00:00.000Z',
+          stalePreviewAgeDays: 1,
+          published: false,
+          verified: false,
+          publishReady: true,
+          publishBlockedByMissingAuth: true,
+          statusUrl: 'https://hol.org/registry/skills/preview/preview_demo',
+          purchaseUrl: 'https://hol.org/registry/skills/submit',
+          publishUrl: 'https://github.com/marketplace/actions/skill-publish',
+          verificationUrl: 'https://hol.org/registry/skills/submit',
+          nextSteps: [
+            {
+              kind: 'publish_first_release',
+              priority: 100,
+              id: 'publish',
+              label: 'Publish the first immutable release',
+              description: 'Publish it.',
+              url: 'https://hol.org/registry/skills/submit',
+              href: 'https://hol.org/registry/skills/submit',
+              command: 'npx skill-publish publish',
+            },
+          ],
+        }),
+      }),
+    );
+
+    const client = new RegistryBrokerClient({
+      baseUrl: 'https://api.example.com',
+      fetchImplementation,
+    });
+
+    const signals = await client.getSkillConversionSignalsByRepo({
+      repo: 'https://github.com/hashgraph-online/registry-broker-skill',
+      skillDir: '.',
+      ref: 'refs/heads/main',
+    });
+
+    expect(signals.publishReady).toBe(true);
+    expect(signals.previewId).toBe('preview_demo');
+    expect(fetchImplementation).toHaveBeenCalledWith(
+      'https://api.example.com/api/v1/skills/conversion-signals/by-repo?repo=https%3A%2F%2Fgithub.com%2Fhashgraph-online%2Fregistry-broker-skill&skillDir=.&ref=refs%2Fheads%2Fmain',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
   it('retrieves skill install metadata for a pinned release', async () => {
     fetchImplementation.mockResolvedValueOnce(
       createResponse({
@@ -501,7 +620,7 @@ describe('RegistryBrokerClient skill contract methods', () => {
             markdownLink:
               '[registry-broker on HOL Registry](https://hol.org/registry/skills/registry-broker?version=1.2.3)',
             htmlLink:
-              '<a href=\"https://hol.org/registry/skills/registry-broker?version=1.2.3\">registry-broker on HOL Registry</a>',
+              '<a href="https://hol.org/registry/skills/registry-broker?version=1.2.3">registry-broker on HOL Registry</a>',
             badge: {
               apiUrl:
                 'https://api.example.com/api/v1/skills/badge?name=registry-broker&metric=version&style=for-the-badge&label=registry-broker',
@@ -509,19 +628,19 @@ describe('RegistryBrokerClient skill contract methods', () => {
                 'https://img.shields.io/endpoint?url=https%3A%2F%2Fapi.example.com%2Fapi%2Fv1%2Fskills%2Fbadge%3Fname%3Dregistry-broker%26metric%3Dversion%26style%3Dfor-the-badge%26label%3Dregistry-broker',
               markdown:
                 '[![registry-broker on HOL Registry (Version + Verification)](https://img.shields.io/endpoint?url=https%3A%2F%2Fapi.example.com%2Fapi%2Fv1%2Fskills%2Fbadge%3Fname%3Dregistry-broker%26metric%3Dversion%26style%3Dfor-the-badge%26label%3Dregistry-broker)](https://hol.org/registry/skills/registry-broker?version=1.2.3)',
-              html: '<a href=\"https://hol.org/registry/skills/registry-broker?version=1.2.3\"><img src=\"https://img.shields.io/endpoint?url=https%3A%2F%2Fapi.example.com%2Fapi%2Fv1%2Fskills%2Fbadge%3Fname%3Dregistry-broker%26metric%3Dversion%26style%3Dfor-the-badge%26label%3Dregistry-broker\" alt=\"registry-broker on HOL Registry (Version + Verification)\" /></a>',
+              html: '<a href="https://hol.org/registry/skills/registry-broker?version=1.2.3"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fapi.example.com%2Fapi%2Fv1%2Fskills%2Fbadge%3Fname%3Dregistry-broker%26metric%3Dversion%26style%3Dfor-the-badge%26label%3Dregistry-broker" alt="registry-broker on HOL Registry (Version + Verification)" /></a>',
             },
           },
           snippets: {
-            cli: 'npx @hol-org/registry skills get --name \"registry-broker\" --version \"1.2.3\"',
+            cli: 'npx @hol-org/registry skills get --name "registry-broker" --version "1.2.3"',
             claude:
-              'Skill URL (Claude):\\nhttps://api.example.com/api/v1/skills/registry-broker%401.2.3/SKILL.md',
+              'Skill URL (Claude):\nhttps://api.example.com/api/v1/skills/registry-broker%401.2.3/SKILL.md',
             cursor:
-              'Skill URL (Cursor):\\nhttps://api.example.com/api/v1/skills/registry-broker%401.2.3/SKILL.md',
+              'Skill URL (Cursor):\nhttps://api.example.com/api/v1/skills/registry-broker%401.2.3/SKILL.md',
             codex:
-              'Skill URL (Codex):\\nhttps://api.example.com/api/v1/skills/registry-broker%401.2.3/SKILL.md',
+              'Skill URL (Codex):\nhttps://api.example.com/api/v1/skills/registry-broker%401.2.3/SKILL.md',
             openclaw:
-              'skill_url: https://api.example.com/api/v1/skills/registry-broker%401.2.3/SKILL.md\\nmanifest_url: https://api.example.com/api/v1/skills/registry-broker%401.2.3/manifest',
+              'skill_url: https://api.example.com/api/v1/skills/registry-broker%401.2.3/SKILL.md\nmanifest_url: https://api.example.com/api/v1/skills/registry-broker%401.2.3/manifest',
           },
         }),
       }),

--- a/src/services/registry-broker/client/base-client.ts
+++ b/src/services/registry-broker/client/base-client.ts
@@ -109,18 +109,6 @@ import type {
   VerificationVerifySenderResponse,
   X402MinimumsResponse,
   SkillRegistryConfigResponse,
-  SkillStatusRequest,
-  SkillStatusResponse,
-  SkillPreviewByRepoRequest,
-  SkillPreviewLookupRequest,
-  SkillPreviewLookupResponse,
-  SkillPreviewRecord,
-  UploadSkillPreviewFromGithubOidcRequest,
-  SkillInstallResponse,
-  SkillInstallCopyTelemetryRequest,
-  SkillInstallCopyTelemetryResponse,
-  SkillSecurityBreakdownRequest,
-  SkillSecurityBreakdownResponse,
   SkillBadgeQuery,
   SkillBadgeResponse,
   SkillCatalogQueryOptions,
@@ -139,9 +127,24 @@ import type {
   SkillRegistryPublishResponse,
   SkillRegistryQuoteRequest,
   SkillRegistryQuoteResponse,
+  SkillQuotePreviewRequest,
+  SkillQuotePreviewResponse,
   SkillRegistryTagsResponse,
   SkillRegistryVoteRequest,
   SkillRegistryVoteStatusResponse,
+  SkillStatusRequest,
+  SkillStatusResponse,
+  SkillPreviewByRepoRequest,
+  SkillPreviewLookupRequest,
+  SkillPreviewLookupResponse,
+  SkillPreviewRecord,
+  SkillConversionSignalsResponse,
+  UploadSkillPreviewFromGithubOidcRequest,
+  SkillInstallResponse,
+  SkillInstallCopyTelemetryRequest,
+  SkillInstallCopyTelemetryResponse,
+  SkillSecurityBreakdownRequest,
+  SkillSecurityBreakdownResponse,
   SkillRecommendedVersionResponse,
   SkillRecommendedVersionSetRequest,
   SkillResolverManifestResponse,
@@ -267,6 +270,7 @@ import {
   getSkillInstall as getSkillInstallImpl,
   getSkillOwnership as getSkillOwnershipImpl,
   getSkillPublishJob as getSkillPublishJobImpl,
+  getSkillConversionSignalsByRepo as getSkillConversionSignalsByRepoImpl,
   getSkillPreviewById as getSkillPreviewByIdImpl,
   getSkillPreviewByRepo as getSkillPreviewByRepoImpl,
   getSkillPreview as getSkillPreviewImpl,
@@ -283,6 +287,7 @@ import {
   listMySkills as listMySkillsImpl,
   listSkillVersions as listSkillVersionsImpl,
   publishSkill as publishSkillImpl,
+  quoteSkillPublishPreview as quoteSkillPublishPreviewImpl,
   quoteSkillPublish as quoteSkillPublishImpl,
   resolveSkillManifest as resolveSkillManifestImpl,
   resolveSkillMarkdown as resolveSkillMarkdownImpl,
@@ -786,22 +791,10 @@ export class RegistryBrokerClient {
     return skillsConfigImpl(this);
   }
 
-  async getSkillStatus(
-    params: SkillStatusRequest,
-  ): Promise<SkillStatusResponse> {
-    return getSkillStatusImpl(this, params);
-  }
-
   async listSkills(
     options?: SkillListOptions,
   ): Promise<SkillRegistryListResponse> {
     return listSkillsImpl(this, options);
-  }
-
-  async getSkillSecurityBreakdown(
-    params: SkillSecurityBreakdownRequest,
-  ): Promise<SkillSecurityBreakdownResponse> {
-    return getSkillSecurityBreakdownImpl(this, params);
   }
 
   async getSkillsCatalog(
@@ -834,6 +827,12 @@ export class RegistryBrokerClient {
     payload: SkillRegistryQuoteRequest,
   ): Promise<SkillRegistryQuoteResponse> {
     return quoteSkillPublishImpl(this, payload);
+  }
+
+  async quoteSkillPublishPreview(
+    payload: SkillQuotePreviewRequest,
+  ): Promise<SkillQuotePreviewResponse> {
+    return quoteSkillPublishPreviewImpl(this, payload);
   }
 
   async publishSkill(
@@ -884,10 +883,28 @@ export class RegistryBrokerClient {
     return getSkillBadgeImpl(this, params);
   }
 
+  async getSkillStatus(
+    params: SkillStatusRequest,
+  ): Promise<SkillStatusResponse> {
+    return getSkillStatusImpl(this, params);
+  }
+
+  async getSkillSecurityBreakdown(
+    params: SkillSecurityBreakdownRequest,
+  ): Promise<SkillSecurityBreakdownResponse> {
+    return getSkillSecurityBreakdownImpl(this, params);
+  }
+
   async getSkillStatusByRepo(
     params: SkillPreviewByRepoRequest,
   ): Promise<SkillStatusResponse> {
     return getSkillStatusByRepoImpl(this, params);
+  }
+
+  async getSkillConversionSignalsByRepo(
+    params: SkillPreviewByRepoRequest,
+  ): Promise<SkillConversionSignalsResponse> {
+    return getSkillConversionSignalsByRepoImpl(this, params);
   }
 
   async uploadSkillPreviewFromGithubOidc(
@@ -1463,7 +1480,7 @@ export class RegistryBrokerClient {
 
   parseWithSchema<T>(
     value: JsonValue,
-    schema: z.ZodType<T, z.ZodTypeDef, unknown>,
+    schema: z.ZodSchema<T>,
     context: string,
   ): T {
     try {
@@ -1529,9 +1546,21 @@ export class RegistryBrokerClient {
     return nodeCrypto;
   }
 
+  private getSecureRandomBytes(size: number, feature: string): Uint8Array {
+    const webCrypto = globalThis.crypto;
+    if (webCrypto && typeof webCrypto.getRandomValues === 'function') {
+      const bytes = new Uint8Array(size);
+      webCrypto.getRandomValues(bytes);
+      return bytes;
+    }
+    return this.getNodeCrypto(feature).randomBytes(size);
+  }
+
   createEphemeralKeyPair(): EphemeralKeyPair {
-    const { randomBytes } = this.getNodeCrypto('generateEphemeralKeyPair');
-    const privateKeyBytes = randomBytes(32);
+    const privateKeyBytes = this.getSecureRandomBytes(
+      32,
+      'generateEphemeralKeyPair',
+    );
     const publicKey = secp256k1.getPublicKey(privateKeyBytes, true);
     return {
       privateKey: Buffer.from(privateKeyBytes).toString('hex'),

--- a/src/services/registry-broker/client/skills.ts
+++ b/src/services/registry-broker/client/skills.ts
@@ -11,19 +11,7 @@ import type {
   SkillRecommendedVersionResponse,
   SkillRecommendedVersionSetRequest,
   SkillRegistryConfigResponse,
-  SkillStatusRequest,
-  SkillStatusResponse,
-  SkillPreviewLookupRequest,
-  SkillPreviewByRepoRequest,
-  SkillPreviewLookupResponse,
-  SkillPreviewRecord,
-  UploadSkillPreviewFromGithubOidcRequest,
-  SkillInstallResponse,
-  SkillInstallCopyTelemetryRequest,
-  SkillInstallCopyTelemetryResponse,
   SkillRegistryCategoriesResponse,
-  SkillSecurityBreakdownRequest,
-  SkillSecurityBreakdownResponse,
   SkillRegistryJobStatusResponse,
   SkillRegistryListResponse,
   SkillRegistryMineResponse,
@@ -33,11 +21,26 @@ import type {
   SkillRegistryPublishResponse,
   SkillRegistryQuoteRequest,
   SkillRegistryQuoteResponse,
+  SkillQuotePreviewRequest,
+  SkillQuotePreviewResponse,
   SkillRegistryTagsResponse,
   SkillRegistryVoteRequest,
   SkillRegistryVoteStatusResponse,
+  SkillStatusRequest,
+  SkillStatusResponse,
+  SkillPreviewLookupRequest,
+  SkillPreviewByRepoRequest,
+  SkillPreviewLookupResponse,
+  SkillPreviewRecord,
+  SkillConversionSignalsResponse,
+  UploadSkillPreviewFromGithubOidcRequest,
+  SkillInstallResponse,
+  SkillInstallCopyTelemetryRequest,
+  SkillInstallCopyTelemetryResponse,
   SkillResolverManifestResponse,
   SkillRegistryVersionsResponse,
+  SkillSecurityBreakdownRequest,
+  SkillSecurityBreakdownResponse,
   SkillVerificationDomainProofChallengeRequest,
   SkillVerificationDomainProofChallengeResponse,
   SkillVerificationDomainProofVerifyRequest,
@@ -53,22 +56,24 @@ import {
   skillDeprecationsResponseSchema,
   skillRecommendedVersionResponseSchema,
   skillRegistryConfigResponseSchema,
-  skillStatusResponseSchema,
-  skillPreviewLookupResponseSchema,
-  skillPreviewRecordSchema,
-  skillInstallResponseSchema,
-  skillInstallCopyTelemetryResponseSchema,
   skillRegistryCategoriesResponseSchema,
   skillRegistryJobStatusResponseSchema,
   skillRegistryListResponseSchema,
-  skillSecurityBreakdownResponseSchema,
   skillRegistryMineResponseSchema,
   skillRegistryMyListResponseSchema,
   skillRegistryOwnershipResponseSchema,
   skillRegistryPublishResponseSchema,
   skillRegistryQuoteResponseSchema,
+  skillQuotePreviewResponseSchema,
+  skillConversionSignalsResponseSchema,
   skillRegistryTagsResponseSchema,
   skillRegistryVoteStatusResponseSchema,
+  skillStatusResponseSchema,
+  skillPreviewLookupResponseSchema,
+  skillPreviewRecordSchema,
+  skillInstallResponseSchema,
+  skillInstallCopyTelemetryResponseSchema,
+  skillSecurityBreakdownResponseSchema,
   skillResolverManifestResponseSchema,
   skillVerificationDomainProofChallengeResponseSchema,
   skillVerificationDomainProofVerifyResponseSchema,
@@ -88,71 +93,6 @@ export async function skillsConfig(
     raw,
     skillRegistryConfigResponseSchema,
     'skill registry config response',
-  );
-}
-
-export async function getSkillStatus(
-  client: RegistryBrokerClient,
-  params: SkillStatusRequest,
-): Promise<SkillStatusResponse> {
-  const normalizedName = params.name.trim();
-  if (!normalizedName) {
-    throw new Error('name is required');
-  }
-
-  const query = new URLSearchParams();
-  query.set('name', normalizedName);
-  if (params.version?.trim()) {
-    query.set('version', params.version.trim());
-  }
-
-  const raw = await client.requestJson<JsonValue>(
-    `/skills/status?${query.toString()}`,
-    {
-      method: 'GET',
-    },
-  );
-
-  return client.parseWithSchema(
-    raw,
-    skillStatusResponseSchema,
-    'skill status response',
-  );
-}
-
-function buildRepoPreviewQuery(params: SkillPreviewByRepoRequest): string {
-  const repo = params.repo.trim();
-  const skillDir = params.skillDir.trim();
-  if (!repo) {
-    throw new Error('repo is required');
-  }
-  if (!skillDir) {
-    throw new Error('skillDir is required');
-  }
-
-  const query = new URLSearchParams();
-  query.set('repo', repo);
-  query.set('skillDir', skillDir);
-  if (params.ref?.trim()) {
-    query.set('ref', params.ref.trim());
-  }
-  return query.toString();
-}
-
-export async function getSkillStatusByRepo(
-  client: RegistryBrokerClient,
-  params: SkillPreviewByRepoRequest,
-): Promise<SkillStatusResponse> {
-  const query = buildRepoPreviewQuery(params);
-  const raw = await client.requestJson<JsonValue>(
-    `/skills/status/by-repo?${query}`,
-    { method: 'GET' },
-  );
-
-  return client.parseWithSchema(
-    raw,
-    skillStatusResponseSchema,
-    'skill status response',
   );
 }
 
@@ -368,6 +308,23 @@ export async function quoteSkillPublish(
   );
 }
 
+export async function quoteSkillPublishPreview(
+  client: RegistryBrokerClient,
+  payload: SkillQuotePreviewRequest,
+): Promise<SkillQuotePreviewResponse> {
+  const raw = await client.requestJson<JsonValue>('/skills/quote-preview', {
+    method: 'POST',
+    body: payload,
+    headers: { 'content-type': 'application/json' },
+  });
+
+  return client.parseWithSchema(
+    raw,
+    skillQuotePreviewResponseSchema,
+    'skill quote preview response',
+  );
+}
+
 export async function publishSkill(
   client: RegistryBrokerClient,
   payload: SkillRegistryPublishRequest,
@@ -572,6 +529,97 @@ export async function getSkillBadge(
   );
 }
 
+export async function getSkillStatus(
+  client: RegistryBrokerClient,
+  params: SkillStatusRequest,
+): Promise<SkillStatusResponse> {
+  const normalizedName = params.name.trim();
+  if (!normalizedName) {
+    throw new Error('name is required');
+  }
+
+  const query = new URLSearchParams();
+  query.set('name', normalizedName);
+  if (params.version?.trim()) {
+    query.set('version', params.version.trim());
+  }
+
+  const raw = await client.requestJson<JsonValue>(
+    `/skills/status?${query.toString()}`,
+    { method: 'GET' },
+  );
+
+  return client.parseWithSchema(
+    raw,
+    skillStatusResponseSchema,
+    'skill status response',
+  );
+}
+
+export async function getSkillStatusByRepo(
+  client: RegistryBrokerClient,
+  params: SkillPreviewByRepoRequest,
+): Promise<SkillStatusResponse> {
+  const repo = params.repo.trim();
+  const skillDir = params.skillDir.trim();
+  if (!repo) {
+    throw new Error('repo is required');
+  }
+  if (!skillDir) {
+    throw new Error('skillDir is required');
+  }
+
+  const query = new URLSearchParams();
+  query.set('repo', repo);
+  query.set('skillDir', skillDir);
+  if (params.ref?.trim()) {
+    query.set('ref', params.ref.trim());
+  }
+
+  const raw = await client.requestJson<JsonValue>(
+    `/skills/status/by-repo?${query.toString()}`,
+    { method: 'GET' },
+  );
+
+  return client.parseWithSchema(
+    raw,
+    skillStatusResponseSchema,
+    'skill status response',
+  );
+}
+
+export async function getSkillConversionSignalsByRepo(
+  client: RegistryBrokerClient,
+  params: SkillPreviewByRepoRequest,
+): Promise<SkillConversionSignalsResponse> {
+  const repo = params.repo.trim();
+  const skillDir = params.skillDir.trim();
+  if (!repo) {
+    throw new Error('repo is required');
+  }
+  if (!skillDir) {
+    throw new Error('skillDir is required');
+  }
+
+  const query = new URLSearchParams();
+  query.set('repo', repo);
+  query.set('skillDir', skillDir);
+  if (params.ref?.trim()) {
+    query.set('ref', params.ref.trim());
+  }
+
+  const raw = await client.requestJson<JsonValue>(
+    `/skills/conversion-signals/by-repo?${query.toString()}`,
+    { method: 'GET' },
+  );
+
+  return client.parseWithSchema(
+    raw,
+    skillConversionSignalsResponseSchema,
+    'skill conversion signals response',
+  );
+}
+
 export async function uploadSkillPreviewFromGithubOidc(
   client: RegistryBrokerClient,
   payload: UploadSkillPreviewFromGithubOidcRequest,
@@ -631,9 +679,24 @@ export async function getSkillPreviewByRepo(
   client: RegistryBrokerClient,
   params: SkillPreviewByRepoRequest,
 ): Promise<SkillPreviewLookupResponse> {
-  const query = buildRepoPreviewQuery(params);
+  const repo = params.repo.trim();
+  const skillDir = params.skillDir.trim();
+  if (!repo) {
+    throw new Error('repo is required');
+  }
+  if (!skillDir) {
+    throw new Error('skillDir is required');
+  }
+
+  const query = new URLSearchParams();
+  query.set('repo', repo);
+  query.set('skillDir', skillDir);
+  if (params.ref?.trim()) {
+    query.set('ref', params.ref.trim());
+  }
+
   const raw = await client.requestJson<JsonValue>(
-    `/skills/preview/by-repo?${query}`,
+    `/skills/preview/by-repo?${query.toString()}`,
     { method: 'GET' },
   );
 

--- a/src/services/registry-broker/schemas.ts
+++ b/src/services/registry-broker/schemas.ts
@@ -156,16 +156,6 @@ const metadataFacetSchema = z
   )
   .optional();
 
-const searchHitMetadataSchema = z
-  .object({
-    delegationRoles: jsonValueSchema.optional(),
-    delegationTaskTags: jsonValueSchema.optional(),
-    delegationProtocols: jsonValueSchema.optional(),
-    delegationSummary: jsonValueSchema.optional(),
-    delegationSignals: jsonValueSchema.optional(),
-  })
-  .passthrough();
-
 const searchHitSchema = z
   .object({
     id: z.string(),
@@ -177,7 +167,7 @@ const searchHitSchema = z
     endpoints: z
       .union([z.record(jsonValueSchema), z.array(z.string())])
       .optional(),
-    metadata: searchHitMetadataSchema.optional(),
+    metadata: z.record(jsonValueSchema).optional(),
     metadataFacet: metadataFacetSchema,
     profile: agentProfileSchema.optional(),
     protocols: z.array(z.string()).optional(),
@@ -231,22 +221,13 @@ export const resolveResponseSchema = z.object({
 const delegationPlanCandidateSchema = z
   .object({
     uaid: z.string(),
-    label: z.string(),
-    registry: z.string().optional(),
-    agent: searchHitSchema,
     score: z.number(),
-    matchedQueries: z.array(z.string()).optional(),
-    matchedRoles: z.array(z.string()).optional(),
-    matchedProtocols: z.array(z.string()).optional(),
-    matchedSurfaces: z.array(z.string()).optional(),
-    matchedLanguages: z.array(z.string()).optional(),
-    matchedArtifacts: z.array(z.string()).optional(),
-    matchedTaskTags: z.array(z.string()).optional(),
-    reasons: z.array(z.string()).optional(),
-    suggestedMessage: z.string().optional(),
-    trustScore: z.number().optional(),
-    verified: z.boolean().optional(),
-    communicationSupported: z.boolean().optional(),
+    displayName: z.string().optional(),
+    summary: z.string().optional(),
+    protocols: z.array(z.string()).optional(),
+    surfaces: z.array(z.string()).optional(),
+    languages: z.array(z.string()).optional(),
+    artifacts: z.array(z.string()).optional(),
     availability: z.boolean().optional(),
     explanation: z.string().optional(),
   })
@@ -1297,7 +1278,7 @@ const trustScoreBreakdownSchema = z
 
 const skillSafetyLabelSchema = z.enum(['safe', 'review', 'caution', 'unsafe']);
 
-export const skillSafetySummarySchema = z
+const skillSafetySummarySchema = z
   .object({
     score: z.number(),
     label: skillSafetyLabelSchema,
@@ -1310,7 +1291,7 @@ export const skillSafetySummarySchema = z
 
 const skillSafetyFindingSeveritySchema = z.enum(['low', 'medium', 'high']);
 
-export const skillSafetyFindingSchema = z
+const skillSafetyFindingSchema = z
   .object({
     ruleId: z.string(),
     severity: skillSafetyFindingSeveritySchema,
@@ -1363,17 +1344,6 @@ export const skillRegistryListResponseSchema = z
   .object({
     items: z.array(skillRegistryPublishSummarySchema),
     nextCursor: z.string().nullable(),
-  })
-  .passthrough();
-
-export const skillSecurityBreakdownResponseSchema = z
-  .object({
-    name: z.string(),
-    version: z.string(),
-    jobId: z.string(),
-    createdAt: z.string(),
-    safety: skillSafetySummarySchema.nullable(),
-    findings: z.array(skillSafetyFindingSchema),
   })
   .passthrough();
 
@@ -1450,183 +1420,14 @@ export const skillDeprecationsResponseSchema = z
   })
   .passthrough();
 
-export const skillPublisherQuickstartCommandSchema = z
+export const skillSecurityBreakdownResponseSchema = z
   .object({
-    id: z.string(),
-    label: z.string(),
-    description: z.string(),
-    command: z.string(),
-    href: z.string().nullable().optional(),
-  })
-  .passthrough();
-
-export const skillPublisherTemplatePresetSchema = z
-  .object({
-    presetId: z.string(),
-    label: z.string(),
-    description: z.string(),
-    recommendedFor: z.string(),
-    command: z.string(),
-  })
-  .passthrough();
-
-export const skillPublisherMetadataSchema = z
-  .object({
-    cliPackageUrl: z.string(),
-    cliCommand: z.string(),
-    actionMarketplaceUrl: z.string(),
-    repositoryUrl: z.string(),
-    guideUrl: z.string().nullable().optional(),
-    docsUrl: z.string().nullable().optional(),
-    submitUrl: z.string().nullable().optional(),
-    skillsIndexUrl: z.string().nullable().optional(),
-    quickstartCommands: z.array(skillPublisherQuickstartCommandSchema),
-    templatePresets: z.array(skillPublisherTemplatePresetSchema),
-  })
-  .passthrough();
-
-export const skillTrustTierSchema = z.enum([
-  'unpublished',
-  'unclaimed',
-  'validated',
-  'published',
-  'verified',
-  'hardened',
-]);
-
-export const skillStatusDefaultVerificationSignals = {
-  publisherBound: false,
-  domainProof: false,
-  verifiedDomain: false,
-  previewValidated: false,
-} as const;
-
-export const skillStatusDefaultProvenanceSignals = {
-  repoCommitIntegrity: false,
-  manifestIntegrity: false,
-  canonicalRelease: false,
-  previewAvailable: false,
-  previewAuthoritative: false,
-} as const;
-
-export const skillStatusChecksSchema = z
-  .object({
-    repoCommitIntegrity: z.boolean(),
-    manifestIntegrity: z.boolean(),
-    domainProof: z.boolean(),
-  })
-  .passthrough();
-
-export const skillStatusNextStepSchema = z
-  .object({
-    kind: z
-      .enum([
-        'setup_validate',
-        'publish_first_release',
-        'verify_domain',
-        'harden_workflow',
-        'share_status',
-      ])
-      .optional(),
-    priority: z.number().int().optional(),
-    id: z.string(),
-    label: z.string(),
-    description: z.string(),
-    url: z.string().nullable().optional(),
-    href: z.string().nullable().optional(),
-    command: z.string().nullable().optional(),
-  })
-  .passthrough();
-
-export const skillPreviewSuggestedNextStepSchema = z
-  .object({
-    id: z.string(),
-    label: z.string(),
-    description: z.string(),
-    command: z.string().optional(),
-    href: z.string().optional(),
-  })
-  .passthrough();
-
-export const skillPreviewReportSchema = z
-  .object({
-    schema_version: z.literal('skill-preview.v1'),
-    tool_version: z.string(),
-    preview_id: z.string(),
-    repo_url: z.string(),
-    repo_owner: z.string(),
-    repo_name: z.string(),
-    default_branch: z.string(),
-    commit_sha: z.string(),
-    ref: z.string(),
-    event_name: z.string(),
-    workflow_run_url: z.string(),
-    skill_dir: z.string(),
-    name: z.string(),
-    version: z.string(),
-    validation_status: z.literal('passed'),
-    findings: z.array(z.unknown()),
-    package_summary: z.record(z.string(), z.unknown()),
-    suggested_next_steps: z.array(skillPreviewSuggestedNextStepSchema),
-    generated_at: z.string(),
-  })
-  .passthrough();
-
-export const skillPreviewRecordSchema = z
-  .object({
-    id: z.string(),
-    previewId: z.string(),
-    source: z.literal('github-oidc'),
-    report: skillPreviewReportSchema,
-    generatedAt: z.string(),
-    expiresAt: z.string(),
-    statusUrl: z.string(),
-    authoritative: z.boolean(),
-  })
-  .passthrough();
-
-export const skillPreviewLookupResponseSchema = z
-  .object({
-    found: z.boolean(),
-    authoritative: z.boolean(),
-    preview: skillPreviewRecordSchema.nullable(),
-    statusUrl: z.string().nullable(),
-    expiresAt: z.string().nullable(),
-  })
-  .passthrough();
-
-export const skillStatusPreviewMetadataSchema = z
-  .object({
-    previewId: z.string(),
-    repoUrl: z.string(),
-    repoOwner: z.string(),
-    repoName: z.string(),
-    commitSha: z.string(),
-    ref: z.string(),
-    eventName: z.string(),
-    skillDir: z.string(),
-    generatedAt: z.string(),
-    expiresAt: z.string(),
-    statusUrl: z.string(),
-  })
-  .passthrough();
-
-export const skillStatusVerificationSignalsSchema = z
-  .object({
-    publisherBound: z.boolean(),
-    domainProof: z.boolean(),
-    verifiedDomain: z.boolean(),
-    previewValidated: z.boolean(),
-  })
-  .passthrough();
-
-export const skillStatusProvenanceSignalsSchema = z
-  .object({
-    repoCommitIntegrity: z.boolean(),
-    manifestIntegrity: z.boolean(),
-    canonicalRelease: z.boolean(),
-    previewAvailable: z.boolean(),
-    previewAuthoritative: z.boolean(),
+    jobId: z.string(),
+    score: z.number().nullable().optional(),
+    findings: z.array(z.unknown()).optional(),
+    summary: z.unknown().optional(),
+    generatedAt: z.string().nullable().optional(),
+    scannerVersion: z.string().nullable().optional(),
   })
   .passthrough();
 
@@ -1644,103 +1445,6 @@ export const skillBadgeMetricSchema = z.enum([
   'upvotes',
   'updated',
 ]);
-
-export const skillStatusResponseSchema = z
-  .object({
-    name: z.string(),
-    version: z.string().nullable(),
-    published: z.boolean(),
-    verifiedDomain: z.boolean(),
-    trustTier: skillTrustTierSchema,
-    badgeMetric: skillBadgeMetricSchema,
-    checks: skillStatusChecksSchema,
-    nextSteps: z.array(skillStatusNextStepSchema),
-    verificationSignals: skillStatusVerificationSignalsSchema.default(
-      skillStatusDefaultVerificationSignals,
-    ),
-    provenanceSignals: skillStatusProvenanceSignalsSchema.default(
-      skillStatusDefaultProvenanceSignals,
-    ),
-    publisher: skillPublisherMetadataSchema.nullable().optional(),
-    preview: skillStatusPreviewMetadataSchema.nullable().optional(),
-    statusUrl: z.string().nullable().optional(),
-  })
-  .passthrough();
-
-export const skillInstallArtifactDescriptorSchema = z
-  .object({
-    url: z.string(),
-    pointer: z.string().nullable(),
-    sha256: z.string().nullable(),
-  })
-  .passthrough();
-
-export const skillInstallResolverDescriptorSchema = z
-  .object({
-    skillRef: z.string(),
-    skillMdUrl: z.string(),
-    manifestUrl: z.string(),
-  })
-  .passthrough();
-
-export const skillInstallBadgeDescriptorSchema = z
-  .object({
-    apiUrl: z.string(),
-    imageUrl: z.string(),
-    markdown: z.string(),
-    html: z.string(),
-  })
-  .passthrough();
-
-export const skillInstallShareDescriptorSchema = z
-  .object({
-    canonicalUrl: z.string().nullable(),
-    latestUrl: z.string().nullable(),
-    markdownLink: z.string().nullable(),
-    htmlLink: z.string().nullable(),
-    badge: skillInstallBadgeDescriptorSchema.nullable(),
-  })
-  .passthrough();
-
-export const skillInstallSnippetSetSchema = z
-  .object({
-    cli: z.string(),
-    claude: z.string(),
-    cursor: z.string(),
-    codex: z.string(),
-    openclaw: z.string(),
-  })
-  .passthrough();
-
-export const skillInstallResponseSchema = z
-  .object({
-    name: z.string(),
-    version: z.string(),
-    skillRef: z.string(),
-    network: z.union([z.literal('mainnet'), z.literal('testnet')]),
-    detailUrl: z.string().nullable(),
-    artifacts: z
-      .object({
-        skillMd: skillInstallArtifactDescriptorSchema,
-        manifest: skillInstallArtifactDescriptorSchema,
-      })
-      .passthrough(),
-    resolvers: z
-      .object({
-        pinned: skillInstallResolverDescriptorSchema,
-        latest: skillInstallResolverDescriptorSchema,
-      })
-      .passthrough(),
-    share: skillInstallShareDescriptorSchema,
-    snippets: skillInstallSnippetSetSchema,
-  })
-  .passthrough();
-
-export const skillInstallCopyTelemetryResponseSchema = z
-  .object({
-    accepted: z.boolean(),
-  })
-  .passthrough();
 
 export const skillBadgeStyleSchema = z.enum([
   'flat',
@@ -1899,7 +1603,47 @@ export const skillRegistryConfigResponseSchema = z
       .union([z.literal('mainnet'), z.literal('testnet')])
       .nullable()
       .optional(),
-    publisher: skillPublisherMetadataSchema.nullable().optional(),
+    publisher: z
+      .object({
+        cliPackageUrl: z.string(),
+        cliCommand: z.string(),
+        actionMarketplaceUrl: z.string(),
+        repositoryUrl: z.string(),
+        guideUrl: z.string().nullable().optional(),
+        docsUrl: z.string().nullable().optional(),
+        submitUrl: z.string().nullable().optional(),
+        skillsIndexUrl: z.string().nullable().optional(),
+        quickstartCommands: z
+          .array(
+            z
+              .object({
+                id: z.string(),
+                label: z.string(),
+                description: z.string(),
+                command: z.string(),
+                href: z.string().nullable().optional(),
+              })
+              .passthrough(),
+          )
+          .optional()
+          .default([]),
+        templatePresets: z
+          .array(
+            z
+              .object({
+                presetId: z.string(),
+                label: z.string(),
+                description: z.string(),
+                recommendedFor: z.string(),
+                command: z.string(),
+              })
+              .passthrough(),
+          )
+          .optional()
+          .default([]),
+      })
+      .nullable()
+      .optional(),
   })
   .passthrough();
 
@@ -1916,6 +1660,267 @@ export const skillRegistryVoteStatusResponseSchema = z
     name: z.string(),
     upvotes: z.number().int(),
     hasUpvoted: z.boolean(),
+  })
+  .passthrough();
+
+export const skillTrustTierSchema = z.enum([
+  'unclaimed',
+  'validated',
+  'published',
+  'verified',
+  'hardened',
+]);
+
+export const skillStatusNextStepSchema = z
+  .object({
+    kind: z.enum([
+      'setup_validate',
+      'publish_first_release',
+      'verify_domain',
+      'harden_workflow',
+      'share_status',
+    ]),
+    priority: z.number().int(),
+    id: z.string(),
+    label: z.string(),
+    description: z.string(),
+    url: z.string().nullable().optional(),
+    href: z.string().nullable().optional(),
+    command: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const skillPreviewSuggestedNextStepSchema = z
+  .object({
+    id: z.string(),
+    label: z.string(),
+    description: z.string(),
+    command: z.string().optional(),
+    href: z.string().optional(),
+  })
+  .passthrough();
+
+export const skillPreviewReportSchema = z
+  .object({
+    schema_version: z.literal('skill-preview.v1'),
+    tool_version: z.string(),
+    preview_id: z.string(),
+    repo_url: z.string(),
+    repo_owner: z.string(),
+    repo_name: z.string(),
+    default_branch: z.string(),
+    commit_sha: z.string(),
+    ref: z.string(),
+    event_name: z.string(),
+    workflow_run_url: z.string(),
+    skill_dir: z.string(),
+    name: z.string(),
+    version: z.string(),
+    validation_status: z.literal('passed'),
+    findings: z.array(z.unknown()),
+    package_summary: z.record(z.string(), z.unknown()),
+    suggested_next_steps: z.array(skillPreviewSuggestedNextStepSchema),
+    generated_at: z.string(),
+  })
+  .passthrough();
+
+export const skillPreviewRecordSchema = z
+  .object({
+    id: z.string(),
+    previewId: z.string(),
+    source: z.literal('github-oidc'),
+    report: skillPreviewReportSchema,
+    generatedAt: z.string(),
+    expiresAt: z.string(),
+    statusUrl: z.string(),
+    authoritative: z.boolean(),
+  })
+  .passthrough();
+
+export const skillPreviewLookupResponseSchema = z
+  .object({
+    found: z.boolean(),
+    authoritative: z.boolean(),
+    preview: skillPreviewRecordSchema.nullable(),
+    statusUrl: z.string().nullable(),
+    expiresAt: z.string().nullable(),
+  })
+  .passthrough();
+
+export const skillStatusPreviewMetadataSchema = z
+  .object({
+    previewId: z.string(),
+    repoUrl: z.string(),
+    repoOwner: z.string(),
+    repoName: z.string(),
+    commitSha: z.string(),
+    ref: z.string(),
+    eventName: z.string(),
+    skillDir: z.string(),
+    generatedAt: z.string(),
+    expiresAt: z.string(),
+    statusUrl: z.string(),
+  })
+  .passthrough();
+
+export const skillStatusChecksSchema = z
+  .object({
+    repoCommitIntegrity: z.boolean(),
+    manifestIntegrity: z.boolean(),
+    domainProof: z.boolean(),
+  })
+  .passthrough();
+
+export const skillStatusVerificationSignalsSchema = z
+  .object({
+    publisherBound: z.boolean(),
+    domainProof: z.boolean(),
+    verifiedDomain: z.boolean(),
+    previewValidated: z.boolean(),
+  })
+  .passthrough();
+
+export const skillStatusProvenanceSignalsSchema = z
+  .object({
+    repoCommitIntegrity: z.boolean(),
+    manifestIntegrity: z.boolean(),
+    canonicalRelease: z.boolean(),
+    previewAvailable: z.boolean(),
+    previewAuthoritative: z.boolean(),
+  })
+  .passthrough();
+
+export const skillStatusResponseSchema = z
+  .object({
+    name: z.string(),
+    version: z.string().nullable(),
+    published: z.boolean(),
+    verifiedDomain: z.boolean(),
+    trustTier: skillTrustTierSchema,
+    badgeMetric: skillBadgeMetricSchema,
+    checks: skillStatusChecksSchema,
+    nextSteps: z.array(skillStatusNextStepSchema),
+    verificationSignals: skillStatusVerificationSignalsSchema,
+    provenanceSignals: skillStatusProvenanceSignalsSchema,
+    publisher: skillRegistryConfigResponseSchema.shape.publisher,
+    preview: skillStatusPreviewMetadataSchema.nullable().optional(),
+    statusUrl: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const skillQuotePreviewRangeSchema = z
+  .object({
+    min: z.number(),
+    max: z.number(),
+  })
+  .passthrough();
+
+export const skillQuotePreviewResponseSchema = z
+  .object({
+    estimatedCredits: skillQuotePreviewRangeSchema,
+    estimatedHbar: skillQuotePreviewRangeSchema,
+    pricingVersion: z.string(),
+    assumptions: z.array(z.string()),
+    purchaseUrl: z.string().nullable(),
+    publishUrl: z.string().nullable(),
+    verificationUrl: z.string().nullable(),
+  })
+  .passthrough();
+
+export const skillConversionSignalsResponseSchema = z
+  .object({
+    repoUrl: z.string(),
+    skillDir: z.string(),
+    trustTier: skillTrustTierSchema,
+    actionInstalled: z.boolean(),
+    previewUploaded: z.boolean(),
+    previewId: z.string().nullable(),
+    lastValidateSuccessAt: z.string().nullable(),
+    stalePreviewAgeDays: z.number().nullable(),
+    published: z.boolean(),
+    verified: z.boolean(),
+    publishReady: z.boolean(),
+    publishBlockedByMissingAuth: z.boolean(),
+    statusUrl: z.string().nullable(),
+    purchaseUrl: z.string().nullable(),
+    publishUrl: z.string().nullable(),
+    verificationUrl: z.string().nullable(),
+    nextSteps: z.array(skillStatusNextStepSchema),
+  })
+  .passthrough();
+
+export const skillInstallArtifactDescriptorSchema = z
+  .object({
+    url: z.string(),
+    pointer: z.string().nullable(),
+    sha256: z.string().nullable(),
+  })
+  .passthrough();
+
+export const skillInstallResolverDescriptorSchema = z
+  .object({
+    skillRef: z.string(),
+    skillMdUrl: z.string(),
+    manifestUrl: z.string(),
+  })
+  .passthrough();
+
+export const skillInstallBadgeDescriptorSchema = z
+  .object({
+    apiUrl: z.string(),
+    imageUrl: z.string(),
+    markdown: z.string(),
+    html: z.string(),
+  })
+  .passthrough();
+
+export const skillInstallShareDescriptorSchema = z
+  .object({
+    canonicalUrl: z.string().nullable(),
+    latestUrl: z.string().nullable(),
+    markdownLink: z.string().nullable(),
+    htmlLink: z.string().nullable(),
+    badge: skillInstallBadgeDescriptorSchema.nullable(),
+  })
+  .passthrough();
+
+export const skillInstallSnippetSetSchema = z
+  .object({
+    cli: z.string(),
+    claude: z.string(),
+    cursor: z.string(),
+    codex: z.string(),
+    openclaw: z.string(),
+  })
+  .passthrough();
+
+export const skillInstallResponseSchema = z
+  .object({
+    name: z.string(),
+    version: z.string(),
+    skillRef: z.string(),
+    network: z.union([z.literal('mainnet'), z.literal('testnet')]),
+    detailUrl: z.string().nullable(),
+    artifacts: z
+      .object({
+        skillMd: skillInstallArtifactDescriptorSchema,
+        manifest: skillInstallArtifactDescriptorSchema,
+      })
+      .passthrough(),
+    resolvers: z
+      .object({
+        pinned: skillInstallResolverDescriptorSchema,
+        latest: skillInstallResolverDescriptorSchema,
+      })
+      .passthrough(),
+    share: skillInstallShareDescriptorSchema,
+    snippets: skillInstallSnippetSetSchema,
+  })
+  .passthrough();
+
+export const skillInstallCopyTelemetryResponseSchema = z
+  .object({
+    accepted: z.boolean(),
   })
   .passthrough();
 

--- a/src/services/registry-broker/types.ts
+++ b/src/services/registry-broker/types.ts
@@ -74,20 +74,6 @@ import {
   verificationVerifyResponseSchema,
   verificationVerifySenderResponseSchema,
   skillRegistryConfigResponseSchema,
-  skillPublisherQuickstartCommandSchema,
-  skillPublisherTemplatePresetSchema,
-  skillPublisherMetadataSchema,
-  skillTrustTierSchema,
-  skillStatusChecksSchema,
-  skillStatusNextStepSchema,
-  skillPreviewSuggestedNextStepSchema,
-  skillPreviewReportSchema,
-  skillPreviewRecordSchema,
-  skillPreviewLookupResponseSchema,
-  skillStatusPreviewMetadataSchema,
-  skillStatusVerificationSignalsSchema,
-  skillStatusProvenanceSignalsSchema,
-  skillStatusResponseSchema,
   skillCatalogChannelSchema,
   skillCatalogSortBySchema,
   skillCatalogVersionSummarySchema,
@@ -104,15 +90,8 @@ import {
   skillResolverManifestResponseSchema,
   skillRegistryFileDescriptorSchema,
   skillRegistryJobStatusResponseSchema,
-  skillRegistryListResponseSchema,
   skillSecurityBreakdownResponseSchema,
-  skillInstallArtifactDescriptorSchema,
-  skillInstallResolverDescriptorSchema,
-  skillInstallBadgeDescriptorSchema,
-  skillInstallShareDescriptorSchema,
-  skillInstallSnippetSetSchema,
-  skillInstallResponseSchema,
-  skillInstallCopyTelemetryResponseSchema,
+  skillRegistryListResponseSchema,
   skillRegistryMineResponseSchema,
   skillRegistryMyListResponseSchema,
   skillRegistryOwnershipResponseSchema,
@@ -125,6 +104,27 @@ import {
   skillVerificationDomainProofVerifyResponseSchema,
   skillVerificationRequestCreateResponseSchema,
   skillVerificationStatusResponseSchema,
+  skillTrustTierSchema,
+  skillStatusNextStepSchema,
+  skillPreviewSuggestedNextStepSchema,
+  skillPreviewReportSchema,
+  skillPreviewRecordSchema,
+  skillPreviewLookupResponseSchema,
+  skillStatusPreviewMetadataSchema,
+  skillStatusChecksSchema,
+  skillStatusVerificationSignalsSchema,
+  skillStatusProvenanceSignalsSchema,
+  skillStatusResponseSchema,
+  skillQuotePreviewRangeSchema,
+  skillQuotePreviewResponseSchema,
+  skillConversionSignalsResponseSchema,
+  skillInstallArtifactDescriptorSchema,
+  skillInstallResolverDescriptorSchema,
+  skillInstallBadgeDescriptorSchema,
+  skillInstallShareDescriptorSchema,
+  skillInstallSnippetSetSchema,
+  skillInstallResponseSchema,
+  skillInstallCopyTelemetryResponseSchema,
 } from './schemas';
 
 export type JsonPrimitive = string | number | boolean | null;
@@ -348,6 +348,9 @@ export type ResolvedAgentResponse = z.infer<typeof resolveResponseSchema>;
 export type CreateSessionResponse = z.infer<typeof createSessionResponseSchema>;
 
 export type SendMessageResponse = z.infer<typeof sendMessageResponseSchema>;
+export type SkillSecurityBreakdownResponse = z.infer<
+  typeof skillSecurityBreakdownResponseSchema
+>;
 export type ChatHistorySnapshotResponse = z.infer<
   typeof chatHistorySnapshotResponseSchema
 >;
@@ -405,9 +408,6 @@ export type SkillRegistryPublishSummary = z.infer<
 export type SkillRegistryListResponse = z.infer<
   typeof skillRegistryListResponseSchema
 >;
-export type SkillSecurityBreakdownResponse = z.infer<
-  typeof skillSecurityBreakdownResponseSchema
->;
 export type SkillRegistryMineResponse = z.infer<
   typeof skillRegistryMineResponseSchema
 >;
@@ -425,55 +425,6 @@ export type SkillRegistryJobStatusResponse = z.infer<
 >;
 export type SkillRegistryConfigResponse = z.infer<
   typeof skillRegistryConfigResponseSchema
->;
-export type SkillPublisherQuickstartCommand = z.infer<
-  typeof skillPublisherQuickstartCommandSchema
->;
-export type SkillPublisherTemplatePreset = z.infer<
-  typeof skillPublisherTemplatePresetSchema
->;
-export type SkillPublisherMetadata = z.infer<
-  typeof skillPublisherMetadataSchema
->;
-export type SkillTrustTier = z.infer<typeof skillTrustTierSchema>;
-export type SkillStatusChecks = z.infer<typeof skillStatusChecksSchema>;
-export type SkillStatusNextStep = z.infer<typeof skillStatusNextStepSchema>;
-export type SkillPreviewSuggestedNextStep = z.infer<
-  typeof skillPreviewSuggestedNextStepSchema
->;
-export type SkillPreviewReport = z.infer<typeof skillPreviewReportSchema>;
-export type SkillPreviewRecord = z.infer<typeof skillPreviewRecordSchema>;
-export type SkillPreviewLookupResponse = z.infer<
-  typeof skillPreviewLookupResponseSchema
->;
-export type SkillStatusPreviewMetadata = z.infer<
-  typeof skillStatusPreviewMetadataSchema
->;
-export type SkillStatusVerificationSignals = z.infer<
-  typeof skillStatusVerificationSignalsSchema
->;
-export type SkillStatusProvenanceSignals = z.infer<
-  typeof skillStatusProvenanceSignalsSchema
->;
-export type SkillStatusResponse = z.infer<typeof skillStatusResponseSchema>;
-export type SkillInstallArtifactDescriptor = z.infer<
-  typeof skillInstallArtifactDescriptorSchema
->;
-export type SkillInstallResolverDescriptor = z.infer<
-  typeof skillInstallResolverDescriptorSchema
->;
-export type SkillInstallBadgeDescriptor = z.infer<
-  typeof skillInstallBadgeDescriptorSchema
->;
-export type SkillInstallShareDescriptor = z.infer<
-  typeof skillInstallShareDescriptorSchema
->;
-export type SkillInstallSnippetSet = z.infer<
-  typeof skillInstallSnippetSetSchema
->;
-export type SkillInstallResponse = z.infer<typeof skillInstallResponseSchema>;
-export type SkillInstallCopyTelemetryResponse = z.infer<
-  typeof skillInstallCopyTelemetryResponseSchema
 >;
 export type SkillCatalogChannel = z.infer<typeof skillCatalogChannelSchema>;
 export type SkillCatalogSortBy = z.infer<typeof skillCatalogSortBySchema>;
@@ -511,6 +462,55 @@ export type SkillRegistryVersionsResponse = z.infer<
 >;
 export type SkillRegistryVoteStatusResponse = z.infer<
   typeof skillRegistryVoteStatusResponseSchema
+>;
+export type SkillTrustTier = z.infer<typeof skillTrustTierSchema>;
+export type SkillStatusNextStep = z.infer<typeof skillStatusNextStepSchema>;
+export type SkillPreviewSuggestedNextStep = z.infer<
+  typeof skillPreviewSuggestedNextStepSchema
+>;
+export type SkillPreviewReport = z.infer<typeof skillPreviewReportSchema>;
+export type SkillPreviewRecord = z.infer<typeof skillPreviewRecordSchema>;
+export type SkillPreviewLookupResponse = z.infer<
+  typeof skillPreviewLookupResponseSchema
+>;
+export type SkillStatusPreviewMetadata = z.infer<
+  typeof skillStatusPreviewMetadataSchema
+>;
+export type SkillStatusChecks = z.infer<typeof skillStatusChecksSchema>;
+export type SkillStatusVerificationSignals = z.infer<
+  typeof skillStatusVerificationSignalsSchema
+>;
+export type SkillStatusProvenanceSignals = z.infer<
+  typeof skillStatusProvenanceSignalsSchema
+>;
+export type SkillStatusResponse = z.infer<typeof skillStatusResponseSchema>;
+export type SkillQuotePreviewRange = z.infer<
+  typeof skillQuotePreviewRangeSchema
+>;
+export type SkillQuotePreviewResponse = z.infer<
+  typeof skillQuotePreviewResponseSchema
+>;
+export type SkillConversionSignalsResponse = z.infer<
+  typeof skillConversionSignalsResponseSchema
+>;
+export type SkillInstallArtifactDescriptor = z.infer<
+  typeof skillInstallArtifactDescriptorSchema
+>;
+export type SkillInstallResolverDescriptor = z.infer<
+  typeof skillInstallResolverDescriptorSchema
+>;
+export type SkillInstallBadgeDescriptor = z.infer<
+  typeof skillInstallBadgeDescriptorSchema
+>;
+export type SkillInstallShareDescriptor = z.infer<
+  typeof skillInstallShareDescriptorSchema
+>;
+export type SkillInstallSnippetSet = z.infer<
+  typeof skillInstallSnippetSetSchema
+>;
+export type SkillInstallResponse = z.infer<typeof skillInstallResponseSchema>;
+export type SkillInstallCopyTelemetryResponse = z.infer<
+  typeof skillInstallCopyTelemetryResponseSchema
 >;
 
 export type SkillVerificationRequestCreateResponse = z.infer<
@@ -563,10 +563,6 @@ export interface SkillListOptions {
   view?: 'latest' | 'all';
 }
 
-export interface SkillSecurityBreakdownRequest {
-  jobId: string;
-}
-
 export interface SkillCatalogQueryOptions {
   q?: string;
   category?: string;
@@ -592,6 +588,10 @@ export interface SkillRegistryVoteRequest {
   upvoted: boolean;
 }
 
+export interface SkillSecurityBreakdownRequest {
+  jobId: string;
+}
+
 export interface SkillStatusRequest {
   name: string;
   version?: string;
@@ -606,6 +606,15 @@ export interface SkillPreviewByRepoRequest {
   repo: string;
   skillDir: string;
   ref?: string;
+}
+
+export interface SkillQuotePreviewRequest {
+  fileCount: number;
+  totalBytes: number;
+  name?: string;
+  version?: string;
+  repoUrl?: string;
+  skillDir?: string;
 }
 
 export interface UploadSkillPreviewFromGithubOidcRequest {


### PR DESCRIPTION
## Summary
- add typed registry broker client support for skill status, preview, quote-preview, conversion signals, and install telemetry
- cover the new methods with focused client tests
- verify the new client methods against production hol.org endpoints

## Verification
- pnpm exec jest --config jest.config.json --coverage=false --runInBand __tests__/services/registry-broker-skills-client.test.ts
- pnpm run typecheck
- pnpm run lint
- pnpm run build
- live quote-preview and conversion-signals calls against https://hol.org/registry/api/v1