### PR TITLE
test: lock browser package export contract

### DIFF
--- a/__tests__/package-exports.test.ts
+++ b/__tests__/package-exports.test.ts
@@ -1,0 +1,77 @@
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+
+type PackageExportTarget =
+  | string
+  | {
+      types?: string;
+      import?: string;
+      browser?: string | PackageExportTarget;
+      require?: string;
+      default?: string;
+    };
+
+type PackageJsonShape = {
+  browser?: string;
+  exports?: Record<string, PackageExportTarget>;
+  scripts?: Record<string, string>;
+};
+
+function readPackageJson(): PackageJsonShape {
+  const packagePath = path.resolve(process.cwd(), 'package.json');
+  const raw = readFileSync(packagePath, 'utf8');
+  return JSON.parse(raw) as PackageJsonShape;
+}
+
+describe('published package contract', () => {
+  it('keeps browser entrypoints exported for consumers', () => {
+    const packageJson = readPackageJson();
+    const rootExport = packageJson.exports?.['.'];
+    const browserExport = packageJson.exports?.['./browser'];
+
+    expect(packageJson.browser).toBe(
+      './dist/browser-root/standards-sdk.root-browser.js',
+    );
+    expect(rootExport).toEqual(
+      expect.objectContaining({
+        browser: expect.objectContaining({
+          types: './dist/browser-root/browser-root.d.ts',
+          default: './dist/browser-root/standards-sdk.root-browser.js',
+        }),
+      }),
+    );
+    expect(browserExport).toEqual(
+      expect.objectContaining({
+        types: './dist/browser/browser.d.ts',
+        import: './dist/browser/standards-sdk.browser.js',
+        browser: './dist/browser/standards-sdk.browser.js',
+        default: './dist/browser/standards-sdk.browser.js',
+      }),
+    );
+  });
+
+  it('builds the browser bundles that back those exports', () => {
+    const packageJson = readPackageJson();
+
+    expect(packageJson.scripts).toEqual(
+      expect.objectContaining({
+        'build:browser-root': 'BUILD_FORMAT=browser-root vite build',
+        'build:browser': 'BUILD_FORMAT=browser vite build',
+      }),
+    );
+    expect(packageJson.scripts?.build).toContain('pnpm run build:browser-root');
+    expect(packageJson.scripts?.build).toContain('pnpm run build:browser');
+    expect(packageJson.scripts?.prepublishOnly).toContain(
+      'pnpm run build:browser-root',
+    );
+    expect(packageJson.scripts?.prepublishOnly).toContain(
+      'pnpm run build:browser',
+    );
+  });
+
+  it('retains the browser-root source entry used by the root browser export', () => {
+    const browserRootPath = path.resolve(process.cwd(), 'src/browser-root.ts');
+
+    expect(existsSync(browserRootPath)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a regression test that locks the browser-facing package contract exposed by `@hashgraphonline/standards-sdk`.

This is the source-side follow-up to the downstream alias churn: the SDK itself should keep exporting and building the browser entrypoints that consumers rely on instead of encouraging package aliases as a workaround.

## What Changed
- adds `__tests__/package-exports.test.ts`
- asserts the root `browser` export still points at `browser-root`
- asserts `./browser` stays exported
- asserts the browser build scripts remain part of `build` and `prepublishOnly`
- asserts `src/browser-root.ts` remains present

## Verification
- `pnpm exec jest --config jest.config.json --runInBand --coverage=false __tests__/browser-entry.test.ts __tests__/package-exports.test.ts`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run build`

## Scope
This PR intentionally avoids unrelated dirty worktree changes in the local checkout and only carries the regression coverage for the package contract.