### PR TITLE
feat: expand guard broker client

### DIFF
--- a/__tests__/services/registry-broker-client.test.ts
+++ b/__tests__/services/registry-broker-client.test.ts
@@ -519,7 +519,9 @@ describe('RegistryBrokerClient', () => {
     expect(targetUrl).toBe('https://api.example.com/api/v1/delegate');
     expect(init?.method).toBe('POST');
     expect(init?.headers).toBeInstanceOf(Headers);
-    expect((init?.headers as Headers).get('content-type')).toBe('application/json');
+    expect((init?.headers as Headers).get('content-type')).toBe(
+      'application/json',
+    );
   });
 
   it('throws RegistryBrokerError on non-OK response', async () => {

--- a/__tests__/services/registry-broker-guard-client.test.ts
+++ b/__tests__/services/registry-broker-guard-client.test.ts
@@ -162,6 +162,11 @@ describe('RegistryBrokerClient guard helpers', () => {
                 reason: 'publisher revoked',
                 severity: 'high',
                 publishedAt: '2026-04-08T18:00:00.000Z',
+                confidence: 0.94,
+                remediation: 'Remove the tool and review prior receipts.',
+                source: 'curated-guard-feed',
+                firstSeenAt: '2026-04-07T18:00:00.000Z',
+                lastUpdatedAt: '2026-04-09T18:00:00.000Z',
               },
             ],
           }),
@@ -188,6 +193,10 @@ describe('RegistryBrokerClient guard helpers', () => {
     expect(trustByHash.match?.artifactName).toBe('hashnet-mcp');
     expect(resolved.items).toHaveLength(1);
     expect(revocations.items[0]?.severity).toBe('high');
+    expect(revocations.items[0]?.source).toBe('curated-guard-feed');
+    expect(revocations.items[0]?.remediation).toBe(
+      'Remove the tool and review prior receipts.',
+    );
   });
 
   it('syncs guard receipts to the broker', async () => {
@@ -246,5 +255,678 @@ describe('RegistryBrokerClient guard helpers', () => {
         }),
       ],
     });
+  });
+
+  it('retrieves artifact abom and round-trips pain signals', async () => {
+    fetchImplementation
+      .mockResolvedValueOnce(
+        createResponse({
+          json: async () => ({
+            generatedAt: '2026-04-11T18:00:00.000Z',
+            summary: {
+              totalArtifacts: 1,
+              totalDevices: 1,
+              totalHarnesses: 1,
+              blockedArtifacts: 1,
+              reviewArtifacts: 0,
+            },
+            items: [
+              {
+                artifactId: 'skill_123',
+                artifactName: 'secret-probe',
+                artifactType: 'skill',
+                artifactSlug: 'secret-probe',
+                harnesses: ['codex'],
+                devices: ['device_123'],
+                eventCount: 1,
+                firstSeenAt: '2026-04-11T17:55:00.000Z',
+                lastSeenAt: '2026-04-11T17:59:00.000Z',
+                latestDecision: 'block',
+                latestRecommendation: 'block',
+                latestHash: 'abc123',
+                latestSummary: 'Reads secrets and calls an external host.',
+              },
+            ],
+          }),
+        }),
+      )
+      .mockResolvedValueOnce(
+        createResponse({
+          json: async () => ({
+            generatedAt: '2026-04-11T18:00:00.000Z',
+            items: [
+              {
+                signalId: 'install_time_block:codex:skill_123',
+                signalName: 'install_time_block',
+                artifactId: 'skill_123',
+                artifactName: 'secret-probe',
+                artifactType: 'skill',
+                harness: 'codex',
+                latestSummary: 'Install blocked before registration.',
+                firstSeenAt: '2026-04-11T17:55:00.000Z',
+                lastSeenAt: '2026-04-11T17:59:00.000Z',
+                count: 2,
+                source: 'scanner',
+              },
+            ],
+          }),
+        }),
+      )
+      .mockResolvedValueOnce(
+        createResponse({
+          json: async () => ({
+            generatedAt: '2026-04-11T18:05:00.000Z',
+            items: [
+              {
+                signalId: 'install_time_block:codex:skill_123',
+                signalName: 'install_time_block',
+                artifactId: 'skill_123',
+                artifactName: 'secret-probe',
+                artifactType: 'skill',
+                harness: 'codex',
+                latestSummary: 'Install blocked before registration.',
+                firstSeenAt: '2026-04-11T17:55:00.000Z',
+                lastSeenAt: '2026-04-11T18:05:00.000Z',
+                count: 3,
+                source: 'scanner',
+              },
+            ],
+          }),
+        }),
+      )
+      .mockResolvedValueOnce(
+        createResponse({
+          json: async () => ({
+            generatedAt: '2026-04-11T18:06:00.000Z',
+            summary: {
+              totalSignals: 1,
+              uniqueArtifacts: 1,
+              uniqueConsumers: 2,
+            },
+            items: [
+              {
+                signalName: 'install_time_block',
+                artifactId: 'skill_123',
+                artifactName: 'secret-probe',
+                artifactType: 'skill',
+                totalCount: 3,
+                consumerCount: 2,
+                harnesses: ['codex'],
+                publishers: ['hashgraph-online'],
+                firstSeenAt: '2026-04-11T17:55:00.000Z',
+                lastSeenAt: '2026-04-11T18:05:00.000Z',
+                latestSummary: 'Install blocked before registration.',
+              },
+            ],
+          }),
+        }),
+      )
+      .mockResolvedValueOnce(
+        createResponse({
+          json: async () => ({
+            name: 'Default team policy',
+            reviewMode: 'prompt',
+            sharedHarnessDefaults: {
+              codex: 'prompt',
+            },
+            allowedPublishers: ['hashgraph-online'],
+            blockedArtifacts: ['skill_123'],
+            blockedPublishers: ['hashgraph-online'],
+            blockedDomains: ['evil.example'],
+            alertChannel: 'email',
+            updatedAt: '2026-04-11T18:06:00.000Z',
+            auditTrail: [
+              {
+                changedAt: '2026-04-11T18:06:00.000Z',
+                actor: 'guard@example.com',
+                change: 'created',
+                summary: 'Created team policy pack.',
+              },
+            ],
+            delegatedApproverEmails: ['security@example.com'],
+          }),
+        }),
+      )
+      .mockResolvedValueOnce(
+        createResponse({
+          json: async () => ({
+            name: 'Default team policy',
+            reviewMode: 'enforce',
+            sharedHarnessDefaults: {
+              codex: 'enforce',
+            },
+            allowedPublishers: ['hashgraph-online'],
+            blockedArtifacts: ['skill_123'],
+            blockedPublishers: ['hashgraph-online', 'unknown-publisher'],
+            blockedDomains: ['evil.example', 'mirror.evil.example'],
+            alertChannel: 'email',
+            updatedAt: '2026-04-11T18:07:00.000Z',
+            auditTrail: [
+              {
+                changedAt: '2026-04-11T18:07:00.000Z',
+                actor: 'guard@example.com',
+                change: 'updated',
+                summary: 'Expanded blocked publishers and domains.',
+              },
+            ],
+            delegatedApproverEmails: ['security@example.com'],
+          }),
+        }),
+      );
+
+    const client = new RegistryBrokerClient({
+      baseUrl: 'https://api.example.com',
+      apiKey: 'rb_test_key',
+      fetchImplementation,
+    });
+
+    const artifactAbom = await client.exportGuardArtifactAbom('skill_123');
+    const painSignals = await client.getGuardPainSignals();
+    const updatedSignals = await client.ingestGuardPainSignals([
+      {
+        signalId: 'install_time_block:codex:skill_123',
+        signalName: 'install_time_block',
+        artifactId: 'skill_123',
+        artifactName: 'secret-probe',
+        artifactType: 'skill',
+        harness: 'codex',
+        latestSummary: 'Install blocked before registration.',
+        occurredAt: '2026-04-11T18:05:00.000Z',
+      },
+    ]);
+    const aggregatedSignals = await client.getGuardAggregatedPainSignals();
+    const teamPolicyPack = await client.getGuardTeamPolicyPack();
+    const updatedTeamPolicyPack = await client.updateGuardTeamPolicyPack({
+      reviewMode: 'enforce',
+      blockedArtifacts: ['skill_123'],
+      blockedPublishers: ['hashgraph-online', 'unknown-publisher'],
+      blockedDomains: ['evil.example', 'mirror.evil.example'],
+      delegatedApproverEmails: ['security@example.com'],
+    });
+
+    expect(artifactAbom.summary.blockedArtifacts).toBe(1);
+    expect(painSignals.items[0]?.count).toBe(2);
+    expect(updatedSignals.items[0]?.count).toBe(3);
+    expect(aggregatedSignals.items[0]?.consumerCount).toBe(2);
+    expect(aggregatedSignals.items[0]?.publishers).toContain(
+      'hashgraph-online',
+    );
+    expect(teamPolicyPack.blockedPublishers).toContain('hashgraph-online');
+    expect(updatedTeamPolicyPack.blockedDomains).toContain(
+      'mirror.evil.example',
+    );
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      1,
+      'https://api.example.com/api/v1/guard/abom/skill_123',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      2,
+      'https://api.example.com/api/v1/guard/signals/pain',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      3,
+      'https://api.example.com/api/v1/guard/signals/pain',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      4,
+      'https://api.example.com/api/v1/guard/signals/pain/aggregate',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      5,
+      'https://api.example.com/api/v1/guard/team/policy-pack',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      6,
+      'https://api.example.com/api/v1/guard/team/policy-pack',
+      expect.objectContaining({ method: 'PUT' }),
+    );
+    const updateRequest = fetchImplementation.mock.calls[5]?.[1] as RequestInit;
+    expect(JSON.parse(String(updateRequest.body))).toMatchObject({
+      blockedPublishers: ['hashgraph-online', 'unknown-publisher'],
+      blockedDomains: ['evil.example', 'mirror.evil.example'],
+    });
+  });
+
+  it('submits guard receipts and retrieves preflight verdicts', async () => {
+    fetchImplementation
+      .mockResolvedValueOnce(
+        createResponse({
+          json: async () => ({
+            syncedAt: '2026-04-12T15:00:00.000Z',
+            receiptsStored: 1,
+            inventoryStored: 0,
+            inventoryDiff: {
+              generatedAt: '2026-04-12T15:00:00.000Z',
+              items: [],
+            },
+            advisories: [],
+            policy: {
+              mode: 'prompt',
+              defaultAction: 'warn',
+              unknownPublisherAction: 'review',
+              changedHashAction: 'require-reapproval',
+              newNetworkDomainAction: 'warn',
+              subprocessAction: 'block',
+              telemetryEnabled: false,
+              syncEnabled: true,
+              updatedAt: '2026-04-12T15:00:00.000Z',
+            },
+            alertPreferences: {
+              emailEnabled: true,
+              digestMode: 'daily',
+              watchlistEnabled: true,
+              advisoriesEnabled: true,
+              repeatedWarningsEnabled: true,
+              teamAlertsEnabled: false,
+              updatedAt: '2026-04-12T15:00:00.000Z',
+            },
+            exceptions: [],
+            teamPolicyPack: {
+              name: 'Default team policy',
+              sharedHarnessDefaults: {
+                hermes: 'enforce',
+              },
+              allowedPublishers: ['hashgraph-online'],
+              blockedPublishers: ['forked-inc'],
+              blockedDomains: ['evil.example'],
+              blockedArtifacts: ['plugin:forked/risky-tool'],
+              alertChannel: 'email',
+              updatedAt: '2026-04-12T15:00:00.000Z',
+              auditTrail: [],
+            },
+          }),
+        }),
+      )
+      .mockResolvedValueOnce(
+        createResponse({
+          json: async () => ({
+            generatedAt: '2026-04-12T15:01:00.000Z',
+            principal: {
+              signedIn: true,
+              principalType: 'service',
+              serviceId: 'hermes-agent',
+              workspaceId: 'workspace-alpha',
+              serviceLabel: 'Hermes Workspace',
+              roles: ['guard:service'],
+            },
+            decision: 'review',
+            recommendation: 'review',
+            rationale: 'Guard wants review before install for Risky Tool.',
+            category: 'trust',
+            confidence: 0.76,
+            freshnessTimestamp: '2026-04-12T15:01:00.000Z',
+            evidenceSources: ['trust-feed'],
+            scope: 'artifact',
+            matchedEvidence: [
+              {
+                category: 'trust',
+                source: 'trust-feed',
+                detail: 'Review required for Risky Tool.',
+              },
+            ],
+            matchedException: null,
+            trustMatch: null,
+          }),
+        }),
+      )
+      .mockResolvedValueOnce(
+        createResponse({
+          json: async () => ({
+            generatedAt: '2026-04-12T15:02:00.000Z',
+            principal: {
+              signedIn: true,
+              principalType: 'service',
+              serviceId: 'hermes-agent',
+              workspaceId: 'workspace-alpha',
+              serviceLabel: 'Hermes Workspace',
+              roles: ['guard:service'],
+            },
+            decision: 'block',
+            recommendation: 'block',
+            rationale: 'Team policy blocks Risky Tool before execution.',
+            category: 'team-policy',
+            confidence: 0.98,
+            freshnessTimestamp: '2026-04-12T15:02:00.000Z',
+            evidenceSources: ['team-policy'],
+            scope: 'artifact',
+            matchedEvidence: [
+              {
+                category: 'team-policy',
+                source: 'team-policy',
+                detail: 'Blocked artifact plugin:forked/risky-tool.',
+              },
+            ],
+            matchedException: null,
+            trustMatch: null,
+          }),
+        }),
+      );
+
+    const client = new RegistryBrokerClient({
+      baseUrl: 'https://api.example.com',
+      apiKey: 'rb_test_key',
+      fetchImplementation,
+    });
+
+    const submitted = await client.submitGuardReceipts({
+      receipts: [
+        {
+          receiptId: 'receipt_456',
+          capturedAt: '2026-04-12T14:59:00.000Z',
+          harness: 'hermes',
+          deviceId: 'workspace-alpha',
+          deviceName: 'Hermes Workspace',
+          artifactId: 'plugin:forked/risky-tool',
+          artifactName: 'Risky Tool',
+          artifactType: 'plugin',
+          artifactSlug: 'forked/risky-tool',
+          artifactHash: 'def456',
+          policyDecision: 'block',
+          recommendation: 'block',
+          changedSinceLastApproval: true,
+          publisher: 'forked-inc',
+          capabilities: ['network.egress'],
+          summary: 'Execution blocked before tool dispatch.',
+        },
+      ],
+    });
+    const installVerdict = await client.getGuardPreInstallVerdict({
+      harness: 'hermes',
+      artifactName: 'Risky Tool',
+      artifactType: 'plugin',
+      artifactId: 'plugin:forked/risky-tool',
+      publisher: 'forked-inc',
+    });
+    const executionVerdict = await client.getGuardPreExecutionVerdict({
+      harness: 'hermes',
+      artifactName: 'Risky Tool',
+      artifactType: 'plugin',
+      artifactId: 'plugin:forked/risky-tool',
+      publisher: 'forked-inc',
+    });
+
+    expect(submitted.receiptsStored).toBe(1);
+    expect(installVerdict.principal.principalType).toBe('service');
+    expect(installVerdict.decision).toBe('review');
+    expect(installVerdict.category).toBe('trust');
+    expect(installVerdict.evidenceSources).toContain('trust-feed');
+    expect(executionVerdict.decision).toBe('block');
+    expect(executionVerdict.category).toBe('team-policy');
+    expect(executionVerdict.evidenceSources).toContain('team-policy');
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      1,
+      'https://api.example.com/api/v1/guard/receipts/submit',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      2,
+      'https://api.example.com/api/v1/guard/verdict/pre-install',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      3,
+      'https://api.example.com/api/v1/guard/verdict/pre-execution',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('retrieves guard overview/feed and uses explicit cloud-agent aliases', async () => {
+    fetchImplementation
+      .mockResolvedValueOnce(
+        createResponse({
+          json: async () => ({
+            generatedAt: '2026-04-12T16:00:00.000Z',
+            items: [
+              {
+                id: 'curated:malicious-skill',
+                artifactType: 'skill',
+                slug: 'malicious-skill',
+                name: 'Malicious Skill',
+                href: '/registry/skills/malicious-skill',
+                ecosystem: 'codex',
+                safetyScore: 12,
+                trustScore: 18,
+                verified: false,
+                recommendation: 'block',
+                updatedAt: '2026-04-12T16:00:00.000Z',
+              },
+            ],
+            summary: {
+              total: 1,
+              monitorCount: 0,
+              reviewCount: 0,
+              blockCount: 1,
+            },
+          }),
+        }),
+      )
+      .mockResolvedValueOnce(
+        createResponse({
+          json: async () => ({
+            generatedAt: '2026-04-12T16:01:00.000Z',
+            principal: {
+              signedIn: true,
+              principalType: 'service',
+              serviceId: 'hermes-agent',
+              workspaceId: 'workspace-alpha',
+              serviceLabel: 'Hermes Workspace',
+              roles: ['guard:service'],
+            },
+            entitlements: {
+              planId: 'team',
+              includedMonthlyCredits: 5000,
+              deviceLimit: 10,
+              retentionDays: 30,
+              syncEnabled: true,
+              premiumFeedsEnabled: true,
+              teamPolicyEnabled: true,
+            },
+            balance: {
+              accountId: 'workspace-alpha',
+              availableCredits: 900,
+            },
+            trustFeed: {
+              generatedAt: '2026-04-12T16:01:00.000Z',
+              items: [],
+              summary: {
+                total: 0,
+                monitorCount: 0,
+                reviewCount: 0,
+                blockCount: 0,
+              },
+            },
+            integrations: [
+              {
+                id: 'hermes',
+                name: 'Hermes',
+                status: 'available',
+                href: '/guard/integrations/hermes',
+                summary: 'Managed workspace policy checks',
+              },
+            ],
+            actionItems: [
+              {
+                title: 'Review risky artifacts',
+                description: 'Check the current risky workspace artifacts.',
+                href: '/guard/review',
+              },
+            ],
+          }),
+        }),
+      )
+      .mockResolvedValueOnce(
+        createResponse({
+          json: async () => ({
+            mode: 'enforce',
+            defaultAction: 'warn',
+            unknownPublisherAction: 'review',
+            changedHashAction: 'require-reapproval',
+            newNetworkDomainAction: 'warn',
+            subprocessAction: 'block',
+            telemetryEnabled: false,
+            syncEnabled: true,
+            updatedAt: '2026-04-12T16:02:00.000Z',
+          }),
+        }),
+      )
+      .mockResolvedValueOnce(
+        createResponse({
+          json: async () => ({
+            generatedAt: '2026-04-12T16:03:00.000Z',
+            items: [
+              {
+                id: 'rev_123',
+                artifactId: 'plugin:forked/risky-tool',
+                artifactName: 'Risky Tool',
+                reason: 'Known malicious maintainer release.',
+                severity: 'high',
+                publishedAt: '2026-04-12T15:50:00.000Z',
+              },
+            ],
+          }),
+        }),
+      )
+      .mockResolvedValueOnce(
+        createResponse({
+          json: async () => ({
+            generatedAt: '2026-04-12T16:04:00.000Z',
+            items: [
+              {
+                exceptionId: 'artifact:plugin:forked/risky-tool',
+                scope: 'artifact',
+                harness: null,
+                artifactId: 'plugin:forked/risky-tool',
+                publisher: null,
+                reason: 'Incident response window',
+                owner: 'security@hashgraph.online',
+                source: 'manual',
+                expiresAt: '2099-01-01T00:00:00.000Z',
+                createdAt: '2026-04-12T16:04:00.000Z',
+                updatedAt: '2026-04-12T16:04:00.000Z',
+              },
+            ],
+          }),
+        }),
+      )
+      .mockResolvedValueOnce(
+        createResponse({
+          json: async () => ({
+            generatedAt: '2026-04-12T16:05:00.000Z',
+            matched: true,
+            scope: 'domain',
+            item: {
+              artifactId: 'plugin:forked/risky-tool',
+              publisher: 'forked-inc',
+              domain: 'evil.example',
+              source: 'team-policy',
+              reason: 'Blocked domain evil.example.',
+            },
+          }),
+        }),
+      )
+      .mockResolvedValueOnce(
+        createResponse({
+          json: async () => ({
+            syncedAt: '2026-04-12T16:06:00.000Z',
+            receiptsStored: 0,
+            inventoryStored: 1,
+          }),
+        }),
+      );
+
+    const client = new RegistryBrokerClient({
+      baseUrl: 'https://api.example.com',
+      apiKey: 'rb_test_key',
+      fetchImplementation,
+    });
+
+    const feed = await client.getGuardFeed(6);
+    const overview = await client.getGuardOverview();
+    const policy = await client.fetchGuardPolicy();
+    const advisories = await client.fetchGuardAdvisories();
+    const exceptions = await client.requestGuardException({
+      scope: 'artifact',
+      artifactId: 'plugin:forked/risky-tool',
+      reason: 'Incident response window',
+      owner: 'security@hashgraph.online',
+      source: 'manual',
+      expiresAt: '2099-01-01T00:00:00.000Z',
+    });
+    const watchlistLookup = await client.lookupGuardWatchlist({
+      harness: 'hermes',
+      artifactName: 'Risky Tool',
+      artifactType: 'plugin',
+      artifactId: 'plugin:forked/risky-tool',
+      publisher: 'forked-inc',
+      domain: 'evil.example',
+    });
+    const inventorySync = await client.syncGuardInventory({
+      receipts: [],
+      inventory: [
+        {
+          artifactId: 'plugin:forked/risky-tool',
+          artifactName: 'Risky Tool',
+          artifactType: 'plugin',
+          artifactSlug: 'forked/risky-tool',
+          harnesses: ['hermes'],
+          devices: ['workspace-alpha'],
+          eventCount: 1,
+          firstSeenAt: '2026-04-12T16:06:00.000Z',
+          lastSeenAt: '2026-04-12T16:06:00.000Z',
+          latestDecision: 'block',
+          latestRecommendation: 'block',
+          latestHash: 'sha256-risky-tool',
+          latestSummary: 'Blocked before execution.',
+        },
+      ],
+    });
+
+    expect(feed.items[0]?.recommendation).toBe('block');
+    expect(overview.principal.principalType).toBe('service');
+    expect(policy.mode).toBe('enforce');
+    expect(advisories.items[0]?.artifactId).toBe('plugin:forked/risky-tool');
+    expect(exceptions.items[0]?.owner).toBe('security@hashgraph.online');
+    expect(watchlistLookup.scope).toBe('domain');
+    expect(inventorySync.inventoryStored).toBe(1);
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      1,
+      'https://api.example.com/api/v1/guard/feed?limit=6',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      2,
+      'https://api.example.com/api/v1/guard/overview',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      3,
+      'https://api.example.com/api/v1/guard/policy/fetch',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      4,
+      'https://api.example.com/api/v1/guard/advisories',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      5,
+      'https://api.example.com/api/v1/guard/exceptions/request',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      6,
+      'https://api.example.com/api/v1/guard/watchlist/lookup',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      7,
+      'https://api.example.com/api/v1/guard/inventory/sync',
+      expect.objectContaining({ method: 'POST' }),
+    );
   });
 });

--- a/__tests__/services/registry-broker-guard-client.test.ts
+++ b/__tests__/services/registry-broker-guard-client.test.ts
@@ -371,8 +371,6 @@ describe('RegistryBrokerClient guard helpers', () => {
             },
             allowedPublishers: ['hashgraph-online'],
             blockedArtifacts: ['skill_123'],
-            blockedPublishers: ['hashgraph-online'],
-            blockedDomains: ['evil.example'],
             alertChannel: 'email',
             updatedAt: '2026-04-11T18:06:00.000Z',
             auditTrail: [
@@ -451,7 +449,7 @@ describe('RegistryBrokerClient guard helpers', () => {
     expect(aggregatedSignals.items[0]?.publishers).toContain(
       'hashgraph-online',
     );
-    expect(teamPolicyPack.blockedPublishers).toContain('hashgraph-online');
+    expect(teamPolicyPack.blockedPublishers ?? []).toEqual([]);
     expect(updatedTeamPolicyPack.blockedDomains).toContain(
       'mirror.evil.example',
     );
@@ -490,6 +488,37 @@ describe('RegistryBrokerClient guard helpers', () => {
       blockedPublishers: ['hashgraph-online', 'unknown-publisher'],
       blockedDomains: ['evil.example', 'mirror.evil.example'],
     });
+  });
+
+  it('omits the guard feed limit query when the truncated value is not positive', async () => {
+    fetchImplementation.mockResolvedValueOnce(
+      createResponse({
+        json: async () => ({
+          generatedAt: '2026-04-12T16:00:00.000Z',
+          items: [],
+          summary: {
+            total: 0,
+            monitorCount: 0,
+            reviewCount: 0,
+            blockCount: 0,
+          },
+        }),
+      }),
+    );
+
+    const client = new RegistryBrokerClient({
+      baseUrl: 'https://api.example.com',
+      apiKey: 'rb_test_key',
+      fetchImplementation,
+    });
+
+    const feed = await client.getGuardFeed(0.5);
+
+    expect(feed.items).toHaveLength(0);
+    expect(fetchImplementation).toHaveBeenCalledWith(
+      'https://api.example.com/api/v1/guard/feed',
+      expect.objectContaining({ method: 'GET' }),
+    );
   });
 
   it('submits guard receipts and retrieves preflight verdicts', async () => {

--- a/__tests__/services/registry-broker-guard-client.test.ts
+++ b/__tests__/services/registry-broker-guard-client.test.ts
@@ -446,6 +446,7 @@ describe('RegistryBrokerClient guard helpers', () => {
     expect(painSignals.items[0]?.count).toBe(2);
     expect(updatedSignals.items[0]?.count).toBe(3);
     expect(aggregatedSignals.items[0]?.consumerCount).toBe(2);
+    expect(aggregatedSignals.summary.totalSignals).toBe(1);
     expect(aggregatedSignals.items[0]?.publishers).toContain(
       'hashgraph-online',
     );
@@ -687,6 +688,8 @@ describe('RegistryBrokerClient guard helpers', () => {
     expect(executionVerdict.decision).toBe('block');
     expect(executionVerdict.category).toBe('team-policy');
     expect(executionVerdict.evidenceSources).toContain('team-policy');
+    expect(submitted.policy?.mode).toBe('prompt');
+    expect(submitted.teamPolicyPack?.name).toBe('Default team policy');
     expect(fetchImplementation).toHaveBeenNthCalledWith(
       1,
       'https://api.example.com/api/v1/guard/receipts/submit',

--- a/src/services/registry-broker/client/base-client.ts
+++ b/src/services/registry-broker/client/base-client.ts
@@ -53,6 +53,9 @@ import type {
   CreditBalanceResponse,
   CreditProvidersResponse,
   GuardBalanceResponse,
+  GuardFeedResponse,
+  GuardOverviewResponse,
+  GuardPolicy,
   GuardAlertPreferences,
   GuardAlertPreferencesUpdate,
   GuardAbomResponse,
@@ -62,6 +65,11 @@ import type {
   GuardExceptionUpsert,
   GuardInventoryDiffResponse,
   GuardInventoryResponse,
+  GuardPainSignalAggregateResponse,
+  GuardPainSignalIngestItem,
+  GuardPainSignalListResponse,
+  GuardPreflightRequest,
+  GuardPreflightVerdictResponse,
   GuardReceiptExportResponse,
   GuardReceiptHistoryResponse,
   GuardReceiptSyncPayload,
@@ -73,6 +81,7 @@ import type {
   GuardTrustByHashResponse,
   GuardTrustResolveQuery,
   GuardTrustResolveResponse,
+  GuardWatchlistLookupResponse,
   GuardWatchlistResponse,
   GuardWatchlistUpsert,
   CreditPurchaseResponse,
@@ -273,9 +282,14 @@ import {
 import {
   exportGuardReceipts as exportGuardReceiptsImpl,
   exportGuardAbom as exportGuardAbomImpl,
+  exportGuardArtifactAbom as exportGuardArtifactAbomImpl,
   addGuardWatchlistItem as addGuardWatchlistItemImpl,
   addGuardException as addGuardExceptionImpl,
+  fetchGuardAdvisories as fetchGuardAdvisoriesImpl,
+  fetchGuardPolicy as fetchGuardPolicyImpl,
   getGuardBillingBalance as getGuardBillingBalanceImpl,
+  getGuardFeed as getGuardFeedImpl,
+  getGuardOverview as getGuardOverviewImpl,
   getGuardReceiptHistory as getGuardReceiptHistoryImpl,
   getGuardArtifactTimeline as getGuardArtifactTimelineImpl,
   getGuardAlertPreferences as getGuardAlertPreferencesImpl,
@@ -284,14 +298,23 @@ import {
   getGuardExceptions as getGuardExceptionsImpl,
   getGuardInventoryDiff as getGuardInventoryDiffImpl,
   getGuardInventory as getGuardInventoryImpl,
+  getGuardPainSignals as getGuardPainSignalsImpl,
+  getGuardAggregatedPainSignals as getGuardAggregatedPainSignalsImpl,
+  getGuardPreExecutionVerdict as getGuardPreExecutionVerdictImpl,
+  getGuardPreInstallVerdict as getGuardPreInstallVerdictImpl,
   getGuardRevocations as getGuardRevocationsImpl,
   getGuardSession as getGuardSessionImpl,
   getGuardTeamPolicyPack as getGuardTeamPolicyPackImpl,
   getGuardTrustByHash as getGuardTrustByHashImpl,
   getGuardWatchlist as getGuardWatchlistImpl,
+  lookupGuardWatchlist as lookupGuardWatchlistImpl,
+  requestGuardException as requestGuardExceptionImpl,
   removeGuardException as removeGuardExceptionImpl,
   removeGuardWatchlistItem as removeGuardWatchlistItemImpl,
   resolveGuardTrust as resolveGuardTrustImpl,
+  ingestGuardPainSignals as ingestGuardPainSignalsImpl,
+  submitGuardReceipts as submitGuardReceiptsImpl,
+  syncGuardInventory as syncGuardInventoryImpl,
   syncGuardReceipts as syncGuardReceiptsImpl,
   updateGuardAlertPreferences as updateGuardAlertPreferencesImpl,
   updateGuardTeamPolicyPack as updateGuardTeamPolicyPackImpl,
@@ -1294,6 +1317,14 @@ export class RegistryBrokerClient {
     return getGuardBillingBalanceImpl(this);
   }
 
+  async getGuardFeed(limit?: number): Promise<GuardFeedResponse> {
+    return getGuardFeedImpl(this, limit);
+  }
+
+  async getGuardOverview(): Promise<GuardOverviewResponse> {
+    return getGuardOverviewImpl(this);
+  }
+
   async getGuardTrustByHash(sha256: string): Promise<GuardTrustByHashResponse> {
     return getGuardTrustByHashImpl(this, sha256);
   }
@@ -1306,6 +1337,14 @@ export class RegistryBrokerClient {
 
   async getGuardRevocations(): Promise<GuardRevocationResponse> {
     return getGuardRevocationsImpl(this);
+  }
+
+  async fetchGuardAdvisories(): Promise<GuardRevocationResponse> {
+    return fetchGuardAdvisoriesImpl(this);
+  }
+
+  async fetchGuardPolicy(): Promise<GuardPolicy> {
+    return fetchGuardPolicyImpl(this);
   }
 
   async getGuardInventory(): Promise<GuardInventoryResponse> {
@@ -1328,6 +1367,12 @@ export class RegistryBrokerClient {
 
   async exportGuardAbom(): Promise<GuardAbomResponse> {
     return exportGuardAbomImpl(this);
+  }
+
+  async exportGuardArtifactAbom(
+    artifactId: string,
+  ): Promise<GuardAbomResponse> {
+    return exportGuardArtifactAbomImpl(this, artifactId);
   }
 
   async exportGuardReceipts(): Promise<GuardReceiptExportResponse> {
@@ -1356,6 +1401,32 @@ export class RegistryBrokerClient {
     return getGuardWatchlistImpl(this);
   }
 
+  async lookupGuardWatchlist(
+    payload: GuardPreflightRequest,
+  ): Promise<GuardWatchlistLookupResponse> {
+    return lookupGuardWatchlistImpl(this, payload);
+  }
+
+  async getGuardPainSignals(): Promise<GuardPainSignalListResponse> {
+    return getGuardPainSignalsImpl(this);
+  }
+
+  async getGuardAggregatedPainSignals(): Promise<GuardPainSignalAggregateResponse> {
+    return getGuardAggregatedPainSignalsImpl(this);
+  }
+
+  async getGuardPreInstallVerdict(
+    payload: GuardPreflightRequest,
+  ): Promise<GuardPreflightVerdictResponse> {
+    return getGuardPreInstallVerdictImpl(this, payload);
+  }
+
+  async getGuardPreExecutionVerdict(
+    payload: GuardPreflightRequest,
+  ): Promise<GuardPreflightVerdictResponse> {
+    return getGuardPreExecutionVerdictImpl(this, payload);
+  }
+
   async addGuardWatchlistItem(
     payload: GuardWatchlistUpsert,
   ): Promise<GuardWatchlistResponse> {
@@ -1374,16 +1445,40 @@ export class RegistryBrokerClient {
     return addGuardExceptionImpl(this, payload);
   }
 
+  async requestGuardException(
+    payload: GuardExceptionUpsert,
+  ): Promise<GuardExceptionListResponse> {
+    return requestGuardExceptionImpl(this, payload);
+  }
+
   async removeGuardException(
     exceptionId: string,
   ): Promise<GuardExceptionListResponse> {
     return removeGuardExceptionImpl(this, exceptionId);
   }
 
+  async ingestGuardPainSignals(
+    items: GuardPainSignalIngestItem[],
+  ): Promise<GuardPainSignalListResponse> {
+    return ingestGuardPainSignalsImpl(this, items);
+  }
+
   async syncGuardReceipts(
     payload: GuardReceiptSyncPayload,
   ): Promise<GuardReceiptSyncResponse> {
     return syncGuardReceiptsImpl(this, payload);
+  }
+
+  async syncGuardInventory(
+    payload: GuardReceiptSyncPayload,
+  ): Promise<GuardReceiptSyncResponse> {
+    return syncGuardInventoryImpl(this, payload);
+  }
+
+  async submitGuardReceipts(
+    payload: GuardReceiptSyncPayload,
+  ): Promise<GuardReceiptSyncResponse> {
+    return submitGuardReceiptsImpl(this, payload);
   }
 
   async getGuardTeamPolicyPack(): Promise<GuardTeamPolicyPack> {

--- a/src/services/registry-broker/client/guard.ts
+++ b/src/services/registry-broker/client/guard.ts
@@ -105,10 +105,15 @@ export async function getGuardFeed(
   limit?: number,
 ): Promise<GuardFeedResponse> {
   const params = new URLSearchParams();
-  if (typeof limit === 'number' && Number.isFinite(limit) && limit > 0) {
+  if (
+    typeof limit === 'number' &&
+    Number.isFinite(limit) &&
+    Math.trunc(limit) > 0
+  ) {
     params.set('limit', String(Math.trunc(limit)));
   }
-  const suffix = params.size > 0 ? `?${params.toString()}` : '';
+  const query = params.toString();
+  const suffix = query ? `?${query}` : '';
   const raw = await client.requestJson<JsonValue>(`/guard/feed${suffix}`, {
     method: 'GET',
   });

--- a/src/services/registry-broker/client/guard.ts
+++ b/src/services/registry-broker/client/guard.ts
@@ -4,11 +4,19 @@ import type {
   GuardAbomResponse,
   GuardArtifactTimelineResponse,
   GuardBalanceResponse,
+  GuardFeedResponse,
+  GuardOverviewResponse,
+  GuardPolicy,
   GuardDeviceListResponse,
   GuardExceptionListResponse,
   GuardExceptionUpsert,
   GuardInventoryDiffResponse,
   GuardInventoryResponse,
+  GuardPainSignalAggregateResponse,
+  GuardPainSignalIngestItem,
+  GuardPainSignalListResponse,
+  GuardPreflightRequest,
+  GuardPreflightVerdictResponse,
   GuardReceiptExportResponse,
   GuardReceiptHistoryResponse,
   GuardReceiptSyncPayload,
@@ -21,6 +29,7 @@ import type {
   GuardTrustResolveQuery,
   GuardTrustResolveResponse,
   GuardWatchlistResponse,
+  GuardWatchlistLookupResponse,
   GuardWatchlistUpsert,
   JsonValue,
 } from '../types';
@@ -29,10 +38,16 @@ import {
   guardAbomResponseSchema,
   guardArtifactTimelineResponseSchema,
   guardBalanceResponseSchema,
+  guardFeedResponseSchema,
+  guardOverviewResponseSchema,
+  guardPolicySchema,
   guardDeviceListResponseSchema,
   guardExceptionListResponseSchema,
   guardInventoryDiffResponseSchema,
   guardInventoryResponseSchema,
+  guardPainSignalListResponseSchema,
+  guardPainSignalAggregateResponseSchema,
+  guardPreflightVerdictResponseSchema,
   guardReceiptExportResponseSchema,
   guardReceiptHistoryResponseSchema,
   guardReceiptSyncResponseSchema,
@@ -41,6 +56,7 @@ import {
   guardTeamPolicyPackSchema,
   guardTrustByHashResponseSchema,
   guardTrustResolveResponseSchema,
+  guardWatchlistLookupResponseSchema,
   guardWatchlistResponseSchema,
 } from '../schemas';
 import type { RegistryBrokerClient } from './base-client';
@@ -81,6 +97,38 @@ export async function getGuardBillingBalance(
     raw,
     guardBalanceResponseSchema,
     'guard billing balance response',
+  );
+}
+
+export async function getGuardFeed(
+  client: RegistryBrokerClient,
+  limit?: number,
+): Promise<GuardFeedResponse> {
+  const params = new URLSearchParams();
+  if (typeof limit === 'number' && Number.isFinite(limit) && limit > 0) {
+    params.set('limit', String(Math.trunc(limit)));
+  }
+  const suffix = params.size > 0 ? `?${params.toString()}` : '';
+  const raw = await client.requestJson<JsonValue>(`/guard/feed${suffix}`, {
+    method: 'GET',
+  });
+  return client.parseWithSchema(
+    raw,
+    guardFeedResponseSchema,
+    'guard feed response',
+  );
+}
+
+export async function getGuardOverview(
+  client: RegistryBrokerClient,
+): Promise<GuardOverviewResponse> {
+  const raw = await client.requestJson<JsonValue>('/guard/overview', {
+    method: 'GET',
+  });
+  return client.parseWithSchema(
+    raw,
+    guardOverviewResponseSchema,
+    'guard overview response',
   );
 }
 
@@ -142,6 +190,32 @@ export async function getGuardRevocations(
   );
 }
 
+export async function fetchGuardAdvisories(
+  client: RegistryBrokerClient,
+): Promise<GuardRevocationResponse> {
+  const raw = await client.requestJson<JsonValue>('/guard/advisories', {
+    method: 'GET',
+  });
+  return client.parseWithSchema(
+    raw,
+    guardRevocationResponseSchema,
+    'guard advisories response',
+  );
+}
+
+export async function fetchGuardPolicy(
+  client: RegistryBrokerClient,
+): Promise<GuardPolicy> {
+  const raw = await client.requestJson<JsonValue>('/guard/policy/fetch', {
+    method: 'GET',
+  });
+  return client.parseWithSchema(
+    raw,
+    guardPolicySchema,
+    'guard policy response',
+  );
+}
+
 export async function getGuardInventory(
   client: RegistryBrokerClient,
 ): Promise<GuardInventoryResponse> {
@@ -197,6 +271,25 @@ export async function exportGuardAbom(
     raw,
     guardAbomResponseSchema,
     'guard abom response',
+  );
+}
+
+export async function exportGuardArtifactAbom(
+  client: RegistryBrokerClient,
+  artifactId: string,
+): Promise<GuardAbomResponse> {
+  const normalizedArtifactId = artifactId.trim();
+  if (!normalizedArtifactId) {
+    throw new Error('artifactId is required');
+  }
+  const raw = await client.requestJson<JsonValue>(
+    `/guard/abom/${encodeURIComponent(normalizedArtifactId)}`,
+    { method: 'GET' },
+  );
+  return client.parseWithSchema(
+    raw,
+    guardAbomResponseSchema,
+    'guard artifact abom response',
   );
 }
 
@@ -293,6 +386,118 @@ export async function getGuardWatchlist(
   );
 }
 
+export async function lookupGuardWatchlist(
+  client: RegistryBrokerClient,
+  payload: GuardPreflightRequest,
+): Promise<GuardWatchlistLookupResponse> {
+  const raw = await client.requestJson<JsonValue>('/guard/watchlist/lookup', {
+    method: 'POST',
+    body: payload,
+  });
+  return client.parseWithSchema(
+    raw,
+    guardWatchlistLookupResponseSchema,
+    'guard watchlist lookup response',
+  );
+}
+
+export async function getGuardPainSignals(
+  client: RegistryBrokerClient,
+): Promise<GuardPainSignalListResponse> {
+  const raw = await client.requestJson<JsonValue>('/guard/signals/pain', {
+    method: 'GET',
+  });
+  return client.parseWithSchema(
+    raw,
+    guardPainSignalListResponseSchema,
+    'guard pain signals response',
+  );
+}
+
+export async function getGuardAggregatedPainSignals(
+  client: RegistryBrokerClient,
+): Promise<GuardPainSignalAggregateResponse> {
+  const raw = await client.requestJson<JsonValue>(
+    '/guard/signals/pain/aggregate',
+    {
+      method: 'GET',
+    },
+  );
+  return client.parseWithSchema(
+    raw,
+    guardPainSignalAggregateResponseSchema,
+    'guard aggregated pain signals response',
+  );
+}
+
+async function getGuardPreflightVerdict(
+  client: RegistryBrokerClient,
+  path: '/guard/verdict/pre-install' | '/guard/verdict/pre-execution',
+  payload: GuardPreflightRequest,
+): Promise<GuardPreflightVerdictResponse> {
+  const raw = await client.requestJson<JsonValue>(path, {
+    method: 'POST',
+    body: payload,
+  });
+  return client.parseWithSchema(
+    raw,
+    guardPreflightVerdictResponseSchema,
+    'guard preflight verdict response',
+  );
+}
+
+export async function getGuardPreInstallVerdict(
+  client: RegistryBrokerClient,
+  payload: GuardPreflightRequest,
+): Promise<GuardPreflightVerdictResponse> {
+  return getGuardPreflightVerdict(
+    client,
+    '/guard/verdict/pre-install',
+    payload,
+  );
+}
+
+export async function getGuardPreExecutionVerdict(
+  client: RegistryBrokerClient,
+  payload: GuardPreflightRequest,
+): Promise<GuardPreflightVerdictResponse> {
+  return getGuardPreflightVerdict(
+    client,
+    '/guard/verdict/pre-execution',
+    payload,
+  );
+}
+
+export async function ingestGuardPainSignals(
+  client: RegistryBrokerClient,
+  items: GuardPainSignalIngestItem[],
+): Promise<GuardPainSignalListResponse> {
+  const raw = await client.requestJson<JsonValue>('/guard/signals/pain', {
+    method: 'POST',
+    body: { items },
+  });
+  return client.parseWithSchema(
+    raw,
+    guardPainSignalListResponseSchema,
+    'guard pain signals response',
+  );
+}
+
+export async function submitGuardReceipts(
+  client: RegistryBrokerClient,
+  payload: GuardReceiptSyncPayload,
+): Promise<GuardReceiptSyncResponse> {
+  const raw = await client.requestJson<JsonValue>('/guard/receipts/submit', {
+    method: 'POST',
+    body: payload,
+  });
+  return client.parseWithSchema(
+    raw,
+    guardReceiptSyncResponseSchema,
+    'guard receipt submit response',
+  );
+}
+
 export async function addGuardWatchlistItem(
   client: RegistryBrokerClient,
   payload: GuardWatchlistUpsert,
@@ -339,6 +544,36 @@ export async function addGuardException(
     raw,
     guardExceptionListResponseSchema,
     'guard exceptions response',
+  );
+}
+
+export async function requestGuardException(
+  client: RegistryBrokerClient,
+  payload: GuardExceptionUpsert,
+): Promise<GuardExceptionListResponse> {
+  const raw = await client.requestJson<JsonValue>('/guard/exceptions/request', {
+    method: 'POST',
+    body: payload,
+  });
+  return client.parseWithSchema(
+    raw,
+    guardExceptionListResponseSchema,
+    'guard exception request response',
+  );
+}
+
+export async function syncGuardInventory(
+  client: RegistryBrokerClient,
+  payload: GuardReceiptSyncPayload,
+): Promise<GuardReceiptSyncResponse> {
+  const raw = await client.requestJson<JsonValue>('/guard/inventory/sync', {
+    method: 'POST',
+    body: payload,
+  });
+  return client.parseWithSchema(
+    raw,
+    guardReceiptSyncResponseSchema,
+    'guard inventory sync response',
   );
 }
 

--- a/src/services/registry-broker/schemas.ts
+++ b/src/services/registry-broker/schemas.ts
@@ -1448,8 +1448,8 @@ export const guardTeamPolicyPackSchema = z.object({
     z.enum(['observe', 'prompt', 'enforce']),
   ),
   allowedPublishers: z.array(z.string()),
-  blockedPublishers: z.array(z.string()),
-  blockedDomains: z.array(z.string()),
+  blockedPublishers: z.array(z.string()).optional(),
+  blockedDomains: z.array(z.string()).optional(),
   blockedArtifacts: z.array(z.string()),
   alertChannel: z.enum(['email', 'slack', 'teams', 'webhook']),
   updatedAt: z.string(),
@@ -1981,8 +1981,8 @@ export const skillSecurityBreakdownResponseSchema = z
   .object({
     jobId: z.string(),
     score: z.number().nullable().optional(),
-    findings: z.array(z.unknown()).optional(),
-    summary: z.unknown().optional(),
+    findings: z.array(jsonValueSchema).optional(),
+    summary: jsonValueSchema.optional(),
     generatedAt: z.string().nullable().optional(),
     scannerVersion: z.string().nullable().optional(),
   })

--- a/src/services/registry-broker/schemas.ts
+++ b/src/services/registry-broker/schemas.ts
@@ -963,10 +963,14 @@ export const guardBucketBalanceSchema = z.object({
 
 export const guardPrincipalSchema = z.object({
   signedIn: z.boolean(),
+  principalType: z.enum(['user', 'service']).default('user'),
   userId: z.string().optional(),
   email: z.string().optional(),
   accountId: z.string().optional(),
   stripeCustomerId: z.string().optional(),
+  serviceId: z.string().optional(),
+  workspaceId: z.string().optional(),
+  serviceLabel: z.string().optional(),
   roles: z.array(z.string()),
 });
 
@@ -997,6 +1001,74 @@ export const guardBalanceResponseSchema = z.object({
   generatedAt: z.string(),
   bucketingMode: z.enum(['shared-ledger', 'product-bucketed']),
   buckets: z.array(guardBucketBalanceSchema),
+});
+
+export const guardFeedItemSchema = z.object({
+  id: z.string(),
+  artifactType: z.enum(['skill', 'plugin']),
+  slug: z.string(),
+  name: z.string(),
+  href: z.string(),
+  ecosystem: z.string().optional(),
+  safetyScore: z.number().nullable().optional(),
+  trustScore: z.number().nullable().optional(),
+  verified: z.boolean(),
+  recommendation: z.enum(['monitor', 'review', 'block']),
+  updatedAt: z.string(),
+});
+
+export const guardFeedSummarySchema = z.object({
+  total: z.number(),
+  monitorCount: z.number(),
+  reviewCount: z.number(),
+  blockCount: z.number(),
+});
+
+export const guardFeedResponseSchema = z.object({
+  generatedAt: z.string(),
+  items: z.array(guardFeedItemSchema),
+  summary: guardFeedSummarySchema,
+});
+
+export const guardIntegrationSchema = z.object({
+  id: z.enum(['openclaw', 'hermes']),
+  name: z.string(),
+  status: z.enum(['available', 'planned']),
+  href: z.string().nullable(),
+  summary: z.string(),
+});
+
+export const guardActionItemSchema = z.object({
+  title: z.string(),
+  description: z.string(),
+  href: z.string(),
+});
+
+export const guardOverviewResponseSchema = z.object({
+  generatedAt: z.string(),
+  principal: guardPrincipalSchema,
+  entitlements: guardEntitlementsSchema,
+  balance: z
+    .object({
+      accountId: z.string(),
+      availableCredits: z.number(),
+    })
+    .nullable(),
+  trustFeed: guardFeedResponseSchema,
+  integrations: z.array(guardIntegrationSchema),
+  actionItems: z.array(guardActionItemSchema),
+});
+
+export const guardPolicySchema = z.object({
+  mode: z.enum(['observe', 'prompt', 'enforce']),
+  defaultAction: z.enum(['allow', 'warn', 'block']),
+  unknownPublisherAction: z.enum(['review', 'block', 'allow']),
+  changedHashAction: z.enum(['allow', 'warn', 'require-reapproval', 'block']),
+  newNetworkDomainAction: z.enum(['allow', 'warn', 'block']),
+  subprocessAction: z.enum(['allow', 'warn', 'block']),
+  telemetryEnabled: z.boolean(),
+  syncEnabled: z.boolean(),
+  updatedAt: z.string(),
 });
 
 export const guardTrustMatchSchema = z.object({
@@ -1038,6 +1110,14 @@ export const guardRevocationSchema = z.object({
   reason: z.string(),
   severity: z.enum(['low', 'medium', 'high']),
   publishedAt: z.string(),
+  confidence: z.number().optional(),
+  remediation: z.string().nullable().optional(),
+  scope: z
+    .enum(['artifact', 'publisher', 'domain', 'workspace', 'ecosystem'])
+    .optional(),
+  source: z.string().optional(),
+  firstSeenAt: z.string().optional(),
+  lastUpdatedAt: z.string().optional(),
 });
 
 export const guardRevocationResponseSchema = z.object({
@@ -1237,6 +1317,60 @@ export const guardWatchlistResponseSchema = z.object({
   items: z.array(guardWatchlistItemSchema),
 });
 
+export const guardWatchlistLookupMatchSchema = z.object({
+  artifactId: z.string().nullable(),
+  publisher: z.string().nullable(),
+  domain: z.string().nullable(),
+  source: z.enum(['watchlist', 'team-policy']),
+  reason: z.string(),
+});
+
+export const guardWatchlistLookupResponseSchema = z.object({
+  generatedAt: z.string(),
+  matched: z.boolean(),
+  scope: z.enum(['artifact', 'publisher', 'domain', 'none']),
+  item: guardWatchlistLookupMatchSchema.nullable(),
+});
+
+export const guardPainSignalSchema = z.object({
+  signalId: z.string(),
+  signalName: z.string(),
+  artifactId: z.string(),
+  artifactName: z.string(),
+  artifactType: z.enum(['skill', 'plugin']),
+  harness: z.string(),
+  latestSummary: z.string(),
+  firstSeenAt: z.string(),
+  lastSeenAt: z.string(),
+  count: z.number(),
+  source: z.literal('scanner'),
+  publisher: z.string().optional(),
+});
+
+export const guardPainSignalListResponseSchema = z.object({
+  generatedAt: z.string(),
+  items: z.array(guardPainSignalSchema),
+});
+
+export const guardPainSignalAggregateSchema = z.object({
+  artifactId: z.string(),
+  artifactName: z.string(),
+  artifactType: z.enum(['skill', 'plugin']),
+  signalName: z.string(),
+  latestSummary: z.string(),
+  firstSeenAt: z.string(),
+  lastSeenAt: z.string(),
+  totalCount: z.number(),
+  consumerCount: z.number(),
+  harnesses: z.array(z.string()),
+  publishers: z.array(z.string()),
+});
+
+export const guardPainSignalAggregateResponseSchema = z.object({
+  generatedAt: z.string(),
+  items: z.array(guardPainSignalAggregateSchema),
+});
+
 export const guardExceptionItemSchema = z.object({
   exceptionId: z.string(),
   scope: z.enum(['artifact', 'publisher', 'harness', 'global']),
@@ -1256,6 +1390,50 @@ export const guardExceptionListResponseSchema = z.object({
   items: z.array(guardExceptionItemSchema),
 });
 
+export const guardPreflightEvidenceSchema = z.object({
+  category: z.enum([
+    'policy',
+    'trust',
+    'watchlist',
+    'team-policy',
+    'exception',
+  ]),
+  source: z.string(),
+  detail: z.string(),
+});
+
+export const guardPreflightRequestSchema = z.object({
+  harness: z.string(),
+  artifactName: z.string(),
+  artifactType: z.enum(['skill', 'plugin']),
+  artifactId: z.string().optional(),
+  artifactSlug: z.string().optional(),
+  artifactHash: z.string().optional(),
+  publisher: z.string().optional(),
+  domain: z.string().optional(),
+  launchSummary: z.string().optional(),
+  capabilities: z.array(z.string()).optional(),
+  workspacePath: z.string().optional(),
+});
+
+export const guardPreflightVerdictResponseSchema = z.object({
+  generatedAt: z.string(),
+  principal: guardPrincipalSchema,
+  decision: z.enum(['allow', 'review', 'block']),
+  recommendation: z.enum(['monitor', 'review', 'block']),
+  rationale: z.string(),
+  category: z
+    .enum(['exception', 'team-policy', 'watchlist', 'trust', 'policy'])
+    .optional(),
+  confidence: z.number().optional(),
+  freshnessTimestamp: z.string().optional(),
+  evidenceSources: z.array(z.string()).optional(),
+  scope: z.enum(['artifact', 'publisher', 'domain', 'policy']),
+  matchedEvidence: z.array(guardPreflightEvidenceSchema),
+  matchedException: guardExceptionItemSchema.nullable(),
+  trustMatch: guardTrustMatchSchema.nullable(),
+});
+
 export const guardTeamPolicyAuditItemSchema = z.object({
   changedAt: z.string(),
   actor: z.string(),
@@ -1265,8 +1443,13 @@ export const guardTeamPolicyAuditItemSchema = z.object({
 
 export const guardTeamPolicyPackSchema = z.object({
   name: z.string(),
-  sharedHarnessDefaults: z.record(z.string(), z.enum(['observe', 'prompt', 'enforce'])),
+  sharedHarnessDefaults: z.record(
+    z.string(),
+    z.enum(['observe', 'prompt', 'enforce']),
+  ),
   allowedPublishers: z.array(z.string()),
+  blockedPublishers: z.array(z.string()),
+  blockedDomains: z.array(z.string()),
   blockedArtifacts: z.array(z.string()),
   alertChannel: z.enum(['email', 'slack', 'teams', 'webhook']),
   updatedAt: z.string(),
@@ -1794,15 +1977,12 @@ export const skillDeprecationsResponseSchema = z
   })
   .passthrough();
 
-const skillSecurityBreakdownFindingSchema = z.record(jsonValueSchema);
-const skillSecurityBreakdownSummarySchema = z.record(jsonValueSchema);
-
 export const skillSecurityBreakdownResponseSchema = z
   .object({
     jobId: z.string(),
     score: z.number().nullable().optional(),
-    findings: z.array(skillSecurityBreakdownFindingSchema).optional(),
-    summary: skillSecurityBreakdownSummarySchema.optional(),
+    findings: z.array(z.unknown()).optional(),
+    summary: z.unknown().optional(),
     generatedAt: z.string().nullable().optional(),
     scannerVersion: z.string().nullable().optional(),
   })

--- a/src/services/registry-broker/schemas.ts
+++ b/src/services/registry-broker/schemas.ts
@@ -1220,6 +1220,11 @@ export const guardReceiptSyncResponseSchema = z.object({
   receiptsStored: z.number(),
   inventoryStored: z.number().optional(),
   inventoryDiff: guardInventoryDiffResponseSchema.optional(),
+  advisories: z.array(guardRevocationSchema).optional(),
+  policy: guardPolicySchema.optional(),
+  alertPreferences: z.lazy(() => guardAlertPreferencesSchema).optional(),
+  exceptions: z.array(z.lazy(() => guardExceptionItemSchema)).optional(),
+  teamPolicyPack: z.lazy(() => guardTeamPolicyPackSchema).optional(),
 });
 
 export const guardInventoryResponseSchema = z.object({
@@ -1368,6 +1373,11 @@ export const guardPainSignalAggregateSchema = z.object({
 
 export const guardPainSignalAggregateResponseSchema = z.object({
   generatedAt: z.string(),
+  summary: z.object({
+    totalSignals: z.number(),
+    uniqueArtifacts: z.number(),
+    uniqueConsumers: z.number(),
+  }),
   items: z.array(guardPainSignalAggregateSchema),
 });
 

--- a/src/services/registry-broker/types.ts
+++ b/src/services/registry-broker/types.ts
@@ -24,6 +24,11 @@ import {
   guardBalanceResponseSchema,
   guardBucketBalanceSchema,
   guardEntitlementsSchema,
+  guardFeedItemSchema,
+  guardFeedResponseSchema,
+  guardFeedSummarySchema,
+  guardOverviewResponseSchema,
+  guardPolicySchema,
   guardPlanIdSchema,
   guardPrincipalSchema,
   guardHistoryArtifactSchema,
@@ -41,11 +46,19 @@ import {
   guardReceiptExportResponseSchema,
   guardAlertPreferencesSchema,
   guardWatchlistItemSchema,
+  guardWatchlistLookupResponseSchema,
   guardWatchlistResponseSchema,
+  guardPainSignalSchema,
+  guardPainSignalListResponseSchema,
+  guardPainSignalAggregateSchema,
+  guardPainSignalAggregateResponseSchema,
   guardInventoryDiffEntrySchema,
   guardInventoryDiffResponseSchema,
   guardExceptionItemSchema,
   guardExceptionListResponseSchema,
+  guardPreflightEvidenceSchema,
+  guardPreflightRequestSchema,
+  guardPreflightVerdictResponseSchema,
   guardTeamPolicyAuditItemSchema,
   guardTeamPolicyPackSchema,
   guardDeviceSchema,
@@ -305,6 +318,16 @@ export type GuardSessionResponse = z.infer<typeof guardSessionResponseSchema>;
 
 export type GuardBalanceResponse = z.infer<typeof guardBalanceResponseSchema>;
 
+export type GuardFeedItem = z.infer<typeof guardFeedItemSchema>;
+
+export type GuardFeedSummary = z.infer<typeof guardFeedSummarySchema>;
+
+export type GuardFeedResponse = z.infer<typeof guardFeedResponseSchema>;
+
+export type GuardOverviewResponse = z.infer<typeof guardOverviewResponseSchema>;
+
+export type GuardPolicy = z.infer<typeof guardPolicySchema>;
+
 export type GuardTrustMatch = z.infer<typeof guardTrustMatchSchema>;
 
 export type GuardTrustByHashResponse = z.infer<
@@ -391,7 +414,51 @@ export interface GuardAlertPreferencesUpdate {
 
 export type GuardWatchlistItem = z.infer<typeof guardWatchlistItemSchema>;
 
-export type GuardWatchlistResponse = z.infer<typeof guardWatchlistResponseSchema>;
+export type GuardWatchlistResponse = z.infer<
+  typeof guardWatchlistResponseSchema
+>;
+
+export type GuardWatchlistLookupResponse = z.infer<
+  typeof guardWatchlistLookupResponseSchema
+>;
+
+export type GuardPainSignal = z.infer<typeof guardPainSignalSchema>;
+
+export type GuardPainSignalAggregate = z.infer<
+  typeof guardPainSignalAggregateSchema
+>;
+
+export type GuardPainSignalListResponse = z.infer<
+  typeof guardPainSignalListResponseSchema
+>;
+
+export type GuardPainSignalAggregateResponse = z.infer<
+  typeof guardPainSignalAggregateResponseSchema
+>;
+
+export type GuardPreflightEvidence = z.infer<
+  typeof guardPreflightEvidenceSchema
+>;
+
+export type GuardPreflightRequest = z.infer<typeof guardPreflightRequestSchema>;
+
+export type GuardPreflightVerdictResponse = z.infer<
+  typeof guardPreflightVerdictResponseSchema
+>;
+
+export interface GuardPainSignalIngestItem {
+  signalId: string;
+  signalName: string;
+  artifactId: string;
+  artifactName: string;
+  artifactType: GuardInventoryArtifact['artifactType'];
+  harness: string;
+  latestSummary: string;
+  occurredAt: string;
+  count?: number;
+  source?: 'scanner';
+  publisher?: string;
+}
 
 export interface GuardWatchlistUpsert {
   artifactId: string;
@@ -426,6 +493,8 @@ export interface GuardTeamPolicyPackUpdate {
   name?: string;
   sharedHarnessDefaults?: GuardTeamPolicyPack['sharedHarnessDefaults'];
   allowedPublishers?: string[];
+  blockedPublishers?: string[];
+  blockedDomains?: string[];
   blockedArtifacts?: string[];
   alertChannel?: GuardTeamPolicyPack['alertChannel'];
 }


### PR DESCRIPTION
Updates Guard client support for the current phase.

## Verification
- pnpm exec jest --config jest.config.json --runTestsByPath __tests__/services/registry-broker-guard-client.test.ts --coverage=false
- pnpm run typecheck
- pnpm run lint
- pnpm run build