### PR TITLE
Add agent chat resume client parity

### DIFF
--- a/__tests__/services/registry-broker-client.test.ts
+++ b/__tests__/services/registry-broker-client.test.ts
@@ -114,6 +114,23 @@ const mockHistorySnapshot = {
   historyTtlSeconds: 900,
 };
 
+const mockResumeResponse = {
+  sessionId: 'session-1',
+  uaid: null,
+  agentUrl: 'https://demo.agent',
+  route: {
+    type: 'a2a',
+    replyMode: 'direct',
+    transport: 'a2a',
+    endpoint: 'https://demo.agent',
+  },
+  transport: 'a2a',
+  history: mockHistorySnapshot.history,
+  historyTtlSeconds: 900,
+  visibility: 'private',
+  state: 'ready',
+};
+
 const mockCompactionResponse = {
   sessionId: 'session-1',
   summaryEntry: {
@@ -478,6 +495,7 @@ describe('RegistryBrokerClient', () => {
     const requiredChatMethods = [
       'start',
       'createSession',
+      'resumeSession',
       'sendMessage',
       'getHistory',
     ] as const;
@@ -1433,6 +1451,11 @@ describe('RegistryBrokerClient', () => {
       )
       .mockResolvedValueOnce(
         createResponse({
+          json: async () => mockResumeResponse,
+        }) as unknown as Response,
+      )
+      .mockResolvedValueOnce(
+        createResponse({
           json: async () => mockMessageResponse,
         }) as unknown as Response,
       )
@@ -1464,6 +1487,7 @@ describe('RegistryBrokerClient', () => {
     const auth: AgentAuthConfig = { type: 'bearer', token: 'user-key' };
     const readiness = await client.chat.readiness({
       agentUrl: 'https://demo.agent',
+      forceRefresh: true,
     });
     expect(readiness.status).toBe('responsive');
 
@@ -1471,9 +1495,13 @@ describe('RegistryBrokerClient', () => {
       agentUrl: 'https://demo.agent',
       auth,
       visibility: 'private',
+      idempotencyKey: 'session-idem-1',
     });
     expect(session.sessionId).toBe('session-1');
     expect(session.route?.type).toBe('a2a');
+
+    const resumed = await client.chat.resumeSession('session-1');
+    expect(resumed.history).toEqual(mockHistorySnapshot.history);
 
     const message = await client.chat.sendMessage({
       agentUrl: 'https://demo.agent',
@@ -1514,6 +1542,12 @@ describe('RegistryBrokerClient', () => {
       'https://api.example.com/api/v1/chat/readiness',
       expect.objectContaining({ method: 'POST' }),
     );
+    const readinessRequestInit = fetchImplementation.mock
+      .calls[0][1] as RequestInit;
+    expect(JSON.parse(readinessRequestInit.body as string)).toEqual({
+      agentUrl: 'https://demo.agent',
+      forceRefresh: true,
+    });
     expect(fetchImplementation).toHaveBeenNthCalledWith(
       2,
       'https://api.example.com/api/v1/chat/session',
@@ -1524,15 +1558,21 @@ describe('RegistryBrokerClient', () => {
     expect(JSON.parse(sessionRequestInit.body as string)).toEqual({
       agentUrl: 'https://demo.agent',
       auth: { type: 'bearer', token: 'user-key' },
+      idempotencyKey: 'session-idem-1',
       visibility: 'private',
     });
     expect(fetchImplementation).toHaveBeenNthCalledWith(
       3,
+      'https://api.example.com/api/v1/chat/session/session-1/resume',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(fetchImplementation).toHaveBeenNthCalledWith(
+      4,
       'https://api.example.com/api/v1/chat/message',
       expect.objectContaining({ method: 'POST' }),
     );
     const messageRequestInit = fetchImplementation.mock
-      .calls[2][1] as RequestInit;
+      .calls[3][1] as RequestInit;
     expect(JSON.parse(messageRequestInit.body as string)).toEqual({
       agentUrl: 'https://demo.agent',
       auth: { type: 'bearer', token: 'user-key' },
@@ -1541,12 +1581,12 @@ describe('RegistryBrokerClient', () => {
       sessionId: 'session-1',
     });
     expect(fetchImplementation).toHaveBeenNthCalledWith(
-      4,
+      5,
       'https://api.example.com/api/v1/chat/message/idem-1/retry',
       expect.objectContaining({ method: 'POST' }),
     );
     const retryRequestInit = fetchImplementation.mock
-      .calls[3][1] as RequestInit;
+      .calls[4][1] as RequestInit;
     expect(JSON.parse(retryRequestInit.body as string)).toEqual({
       cipherEnvelope: {
         algorithm: 'aes-256-gcm',
@@ -1559,12 +1599,12 @@ describe('RegistryBrokerClient', () => {
       sessionId: 'session-1',
     });
     expect(fetchImplementation).toHaveBeenNthCalledWith(
-      5,
+      6,
       'https://api.example.com/api/v1/chat/session/session-1/cancel',
       expect.objectContaining({ method: 'POST' }),
     );
     expect(fetchImplementation).toHaveBeenNthCalledWith(
-      6,
+      7,
       'https://api.example.com/api/v1/chat/session/session-1',
       expect.objectContaining({ method: 'DELETE' }),
     );
@@ -1654,6 +1694,9 @@ describe('RegistryBrokerClient', () => {
       'sessionId is required',
     );
     await expect(client.chat.endSession('   ')).rejects.toThrow(
+      'sessionId is required',
+    );
+    await expect(client.chat.resumeSession('   ')).rejects.toThrow(
       'sessionId is required',
     );
     await expect(

--- a/src/services/registry-broker/client/base-client.ts
+++ b/src/services/registry-broker/client/base-client.ts
@@ -51,6 +51,7 @@ import type {
   ChatRetryRequestPayload,
   ChatRetryResponse,
   ChatSessionEndResponse,
+  ChatSessionResumeResponse,
   CipherEnvelope,
   CompactHistoryRequestPayload,
   CreateAdapterRegistryCategoryRequest,
@@ -230,6 +231,7 @@ import {
   fetchEncryptionStatus as fetchEncryptionStatusImpl,
   postEncryptionHandshake as postEncryptionHandshakeImpl,
   retryMessage as retryMessageImpl,
+  resumeSession as resumeSessionImpl,
   sendMessage as sendMessageImpl,
   startChat as startChatImpl,
   startConversation as startConversationImpl,
@@ -1712,6 +1714,10 @@ export class RegistryBrokerClient {
     allowHistoryAutoTopUp = true,
   ): Promise<CreateSessionResponse> {
     return createSessionImpl(this, payload, allowHistoryAutoTopUp);
+  }
+
+  async resumeSession(sessionId: string): Promise<ChatSessionResumeResponse> {
+    return resumeSessionImpl(this, sessionId);
   }
 
   async checkChatReadiness(

--- a/src/services/registry-broker/client/chat.ts
+++ b/src/services/registry-broker/client/chat.ts
@@ -12,6 +12,7 @@ import type {
   ChatRetryRequestPayload,
   ChatRetryResponse,
   ChatSessionEndResponse,
+  ChatSessionResumeResponse,
   CompactHistoryRequestPayload,
   CreateSessionRequestPayload,
   CreateSessionResponse,
@@ -32,6 +33,7 @@ import {
   chatHistoryCompactionResponseSchema,
   chatReadinessResponseSchema,
   chatSessionEndResponseSchema,
+  chatSessionResumeResponseSchema,
   createSessionResponseSchema,
   encryptionHandshakeResponseSchema,
   sendMessageResponseSchema,
@@ -52,6 +54,7 @@ export interface RegistryBrokerChatApi {
   createSession: (
     payload: CreateSessionRequestPayload,
   ) => Promise<CreateSessionResponse>;
+  resumeSession: (sessionId: string) => Promise<ChatSessionResumeResponse>;
   sendMessage: (
     payload: SendMessageRequestPayload,
   ) => Promise<SendMessageResponse>;
@@ -99,6 +102,7 @@ export function createChatApi(
       client.checkChatReadiness(payload),
     createSession: (payload: CreateSessionRequestPayload) =>
       client.createSession(payload),
+    resumeSession: (sessionId: string) => client.resumeSession(sessionId),
     sendMessage: (payload: SendMessageRequestPayload) =>
       client.sendMessage(payload),
     retryMessage: (messageId: string, payload: ChatRetryRequestPayload) =>
@@ -142,6 +146,9 @@ export async function checkChatReadiness(
   if (agentUrl) {
     body.agentUrl = agentUrl;
   }
+  if (payload.forceRefresh !== undefined) {
+    body.forceRefresh = payload.forceRefresh;
+  }
   const raw = await client.requestJson<JsonValue>('/chat/readiness', {
     method: 'POST',
     body,
@@ -181,6 +188,9 @@ export async function createSession(
   if (payload.visibility) {
     body.visibility = payload.visibility;
   }
+  if (payload.idempotencyKey) {
+    body.idempotencyKey = payload.idempotencyKey;
+  }
   try {
     const raw = await client.requestJson<JsonValue>('/chat/session', {
       method: 'POST',
@@ -203,6 +213,25 @@ export async function createSession(
     }
     throw error;
   }
+}
+
+export async function resumeSession(
+  client: RegistryBrokerClient,
+  sessionId: string,
+): Promise<ChatSessionResumeResponse> {
+  const normalized = sessionId.trim();
+  if (!normalized) {
+    throw new Error('sessionId is required to resume a chat session');
+  }
+  const raw = await client.requestJson<JsonValue>(
+    `/chat/session/${encodeURIComponent(normalized)}/resume`,
+    { method: 'GET' },
+  );
+  return client.parseWithSchema(
+    raw,
+    chatSessionResumeResponseSchema,
+    'chat session resume response',
+  );
 }
 
 export async function startChat(

--- a/src/services/registry-broker/schemas.ts
+++ b/src/services/registry-broker/schemas.ts
@@ -166,6 +166,42 @@ const chatDeliveryStateSchema = z.enum([
   'cancelled',
 ]);
 
+const chatAttachmentStateSchema = z.object({
+  supported: z.boolean(),
+  status: z.enum([
+    'unsupported',
+    'available',
+    'selected',
+    'uploading',
+    'scanning',
+    'ready',
+    'failed',
+    'rejected',
+  ]),
+  maxBytes: z.number().nullable().optional(),
+  acceptedMimeTypes: z.array(z.string()).optional(),
+  reason: z.string().optional(),
+});
+
+export const chatTimelineEntrySchema = z.object({
+  messageId: z.string(),
+  kind: z.enum([
+    'user',
+    'assistant',
+    'system',
+    'tool',
+    'payment',
+    'delivery',
+    'error',
+  ]),
+  content: z.string(),
+  timestamp: z.string(),
+  deliveryState: chatDeliveryStateSchema.optional(),
+  errorCode: z.string().optional(),
+  metadata: z.record(jsonValueSchema).optional(),
+  attachment: chatAttachmentStateSchema.optional(),
+});
+
 const chatReadinessStatusSchema = z.enum([
   'responsive',
   'delivery_only',
@@ -271,6 +307,18 @@ export const chatReadinessResponseSchema = z.object({
       details: z.string().optional(),
     })
     .optional(),
+});
+
+export const chatSessionResumeResponseSchema = z.object({
+  sessionId: z.string(),
+  uaid: z.string().nullable().optional(),
+  agentUrl: z.string().nullable().optional(),
+  route: chatRouteSummarySchema,
+  transport: z.string(),
+  history: z.array(chatHistoryEntrySchema),
+  historyTtlSeconds: z.number().optional(),
+  visibility: z.enum(['private', 'public']).optional(),
+  state: chatSessionStateSchema,
 });
 
 const metadataFacetSchema = z

--- a/src/services/registry-broker/types.ts
+++ b/src/services/registry-broker/types.ts
@@ -92,7 +92,9 @@ import {
   searchResponseSchema,
   sendMessageResponseSchema,
   chatReadinessResponseSchema,
+  chatSessionResumeResponseSchema,
   chatSessionEndResponseSchema,
+  chatTimelineEntrySchema,
   chatRouteSummarySchema,
   chatPaymentStateSchema,
   chatHistorySnapshotResponseSchema,
@@ -209,6 +211,8 @@ export interface RegistryBrokerClientOptions {
 export type ChatHistoryEntry = z.infer<
   typeof createSessionResponseSchema
 >['history'][number];
+
+export type ChatTimelineEntry = z.infer<typeof chatTimelineEntrySchema>;
 
 export type CipherEnvelope = NonNullable<ChatHistoryEntry['cipherEnvelope']>;
 
@@ -616,6 +620,10 @@ export type PopularSearchesResponse = z.infer<typeof popularResponseSchema>;
 export type ResolvedAgentResponse = z.infer<typeof resolveResponseSchema>;
 
 export type CreateSessionResponse = z.infer<typeof createSessionResponseSchema>;
+
+export type ChatSessionResumeResponse = z.infer<
+  typeof chatSessionResumeResponseSchema
+>;
 
 export type SendMessageResponse = z.infer<typeof sendMessageResponseSchema>;
 export type ChatReadinessResponse = z.infer<typeof chatReadinessResponseSchema>;
@@ -1146,6 +1154,7 @@ type CreateSessionBasePayload = {
   encryptionRequested?: boolean;
   senderUaid?: string;
   visibility?: 'private' | 'public';
+  idempotencyKey?: string;
 };
 
 export type CreateSessionRequestPayload =
@@ -1153,8 +1162,8 @@ export type CreateSessionRequestPayload =
   | (CreateSessionBasePayload & { agentUrl: string });
 
 export type ChatReadinessRequestPayload =
-  | { uaid: string; agentUrl?: never }
-  | { agentUrl: string; uaid?: never };
+  | { uaid: string; agentUrl?: never; forceRefresh?: boolean }
+  | { agentUrl: string; uaid?: never; forceRefresh?: boolean };
 
 export interface ChatRetryRequestPayload extends SendMessageBasePayload {
   sessionId: string;


### PR DESCRIPTION
## Shipped behavior
- Adds chat timeline and resume schemas/types to the Registry Broker client surface.
- Adds readiness force-refresh and create-session idempotency payload support.
- Adds `resumeSession` helpers on the chat API and top-level client.

## Verification
- `pnpm run typecheck` -> passed.
- `pnpm run lint` -> passed.
- `pnpm run build` -> build success.
- `pnpm exec jest --config jest.config.json --coverage=false --runTestsByPath __tests__/services/registry-broker-client.test.ts --runInBand` -> 44 passed.
- Shared no-mock Docker stack: `docker compose --profile extras up -d elasticsearch rocksdb-sidecar qdrant registry-broker ping-agent && pnpm run e2e:agent-chat` -> registration 200, readiness responsive/a2a, session idempotency true, send assistant_response, history user+agent, resume entries 2, retry responded, duplicate end ended.