### PR TITLE
feat(registry-broker): export chat type system (RouteType, ReplyMode, ErrorCode, SessionState, DeliveryState, ReadinessStatus)

### DIFF
--- a/src/services/registry-broker/index.ts
+++ b/src/services/registry-broker/index.ts
@@ -3,3 +3,12 @@ export * from './types';
 export * from './private-key-signer';
 export * from './ledger-network';
 export * from './hol-chat-ops';
+export {
+  chatDeliveryStateSchema,
+  chatReadinessStatusSchema,
+  chatReplyModeSchema,
+  chatRouteTypeSchema,
+  chatSessionStateSchema,
+  chatErrorCodeSchema,
+  chatTimelineEntrySchema,
+} from './schemas';

--- a/src/services/registry-broker/schemas.ts
+++ b/src/services/registry-broker/schemas.ts
@@ -155,6 +155,7 @@ const chatHistoryEntrySchema = z.object({
 });
 
 export const chatDeliveryStateSchema = z.enum([
+  'draft',
   'queued',
   'persisted',
   'delivered',

--- a/src/services/registry-broker/schemas.ts
+++ b/src/services/registry-broker/schemas.ts
@@ -154,8 +154,7 @@ const chatHistoryEntrySchema = z.object({
   metadata: z.record(jsonValueSchema).optional(),
 });
 
-const chatDeliveryStateSchema = z.enum([
-  'draft',
+export const chatDeliveryStateSchema = z.enum([
   'queued',
   'persisted',
   'delivered',
@@ -202,7 +201,7 @@ export const chatTimelineEntrySchema = z.object({
   attachment: chatAttachmentStateSchema.optional(),
 });
 
-const chatReadinessStatusSchema = z.enum([
+export const chatReadinessStatusSchema = z.enum([
   'responsive',
   'delivery_only',
   'degraded',
@@ -210,7 +209,7 @@ const chatReadinessStatusSchema = z.enum([
   'unknown',
 ]);
 
-const chatReplyModeSchema = z.enum([
+export const chatReplyModeSchema = z.enum([
   'direct',
   'stream',
   'poll',
@@ -218,7 +217,7 @@ const chatReplyModeSchema = z.enum([
   'none',
 ]);
 
-const chatRouteTypeSchema = z.enum([
+export const chatRouteTypeSchema = z.enum([
   'a2a',
   'hcs-10',
   'mcp',
@@ -234,7 +233,7 @@ const chatRouteTypeSchema = z.enum([
   'unknown',
 ]);
 
-const chatSessionStateSchema = z.enum([
+export const chatSessionStateSchema = z.enum([
   'connecting',
   'ready',
   'blocked',
@@ -242,7 +241,7 @@ const chatSessionStateSchema = z.enum([
   'expired',
 ]);
 
-const chatErrorCodeSchema = z.enum([
+export const chatErrorCodeSchema = z.enum([
   'AUTH_REQUIRED',
   'CREDITS_REQUIRED',
   'PAYMENT_REQUIRED',

--- a/src/services/registry-broker/types.ts
+++ b/src/services/registry-broker/types.ts
@@ -97,6 +97,12 @@ import {
   chatTimelineEntrySchema,
   chatRouteSummarySchema,
   chatPaymentStateSchema,
+  chatDeliveryStateSchema,
+  chatReadinessStatusSchema,
+  chatReplyModeSchema,
+  chatRouteTypeSchema,
+  chatSessionStateSchema,
+  chatErrorCodeSchema,
   chatHistorySnapshotResponseSchema,
   chatHistoryCompactionResponseSchema,
   statsResponseSchema,
@@ -632,6 +638,12 @@ export type ChatSessionEndResponse = z.infer<
 >;
 export type ChatRouteSummary = z.infer<typeof chatRouteSummarySchema>;
 export type ChatPaymentState = z.infer<typeof chatPaymentStateSchema>;
+export type ChatDeliveryState = z.infer<typeof chatDeliveryStateSchema>;
+export type ChatReadinessStatus = z.infer<typeof chatReadinessStatusSchema>;
+export type ChatReplyMode = z.infer<typeof chatReplyModeSchema>;
+export type ChatRouteType = z.infer<typeof chatRouteTypeSchema>;
+export type ChatSessionState = z.infer<typeof chatSessionStateSchema>;
+export type ChatErrorCode = z.infer<typeof chatErrorCodeSchema>;
 export type ChatRetryResponse = SendMessageResponse;
 export type SkillSecurityBreakdownResponse = z.infer<
   typeof skillSecurityBreakdownResponseSchema


### PR DESCRIPTION
## Changes

Exports the complete chat type system from `@hashgraphonline/standards-sdk`:

### New type exports
- `ChatRouteType` — routing protocol identifier (a2a, hcs-10, mcp, openrouter, etc.)
- `ChatReplyMode` — reply mode (direct, stream, poll, delivery_only, none)
- `ChatErrorCode` — error code enum
- `ChatSessionState` — session lifecycle (connecting, ready, blocked, ended, expired)
- `ChatDeliveryState` — delivery lifecycle (draft, queued, persisted, delivered, etc.)
- `ChatReadinessStatus` — readiness status (responsive, delivery_only, degraded, blocked, unknown)

### Schema exports
All above schemas are now exported so consumers can do runtime validation with Zod.

### Previously exported (confirmed working)
- `ChatTimelineEntry`, `ChatHistoryResponse`, `ChatDelegatePlan` (unchanged)

## Verification

```
pnpm run build    # exit 0
pnpm test -- --runInBand __tests__/services/registry-broker-client.test.ts
# Tests: 44 passed
```